### PR TITLE
Typo and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,15 +54,15 @@ If a feature is missing that you would like to see feel free to create a [Featur
 
 Nightly Builds
 ---------------
-- [🐧 Linux Editor](https://nightly.link/WeaselGames/lua/workflows/linux/main/linux-editor.zip)
-- [🐧 Linux Template](https://nightly.link/WeaselGames/lua/workflows/linux/main/linux-template-release.zip)
-- [🐧 Linux Template Debug](https://nightly.link/WeaselGames/lua/workflows/linux/main/linux-template-debug.zip)
-- [🎨 Windows Editor](https://nightly.link/WeaselGames/lua/workflows/windows/main/windows-editor.zip)
-- [🎨 Windows Template](https://nightly.link/WeaselGames/lua/workflows/windows/main/windows-template.zip)
-- [🎨 Windows Template Debug](https://nightly.link/WeaselGames/lua/workflows/windows/main/windows-template-debug.zip)
-- [🍎 MacOS Editor](https://nightly.link/WeaselGames/lua/workflows/macos/main/macos-editor.zip)
-- [🍎 MacOS Templates](https://nightly.link/WeaselGames/lua/workflows/macos/main/macos-template.zip)
-- [🍎 MacOS Templates Debug](https://nightly.link/WeaselGames/lua/workflows/macos/main/macos-template-debug.zip)
+- [🐧 Linux Editor](https://nightly.link/WeaselGames/godot_luaAPI/workflows/linux/main/linux-editor.zip)
+- [🐧 Linux Template](https://nightly.link/WeaselGames/godot_luaAPI/workflows/linux/main/linux-template-release.zip)
+- [🐧 Linux Template Debug](https://nightly.link/WeaselGames/godot_luaAPI/workflows/linux/main/linux-template-debug.zip)
+- [🎨 Windows Editor](https://nightly.link/WeaselGames/godot_luaAPI/workflows/windows/main/windows-editor.zip)
+- [🎨 Windows Template](https://nightly.link/WeaselGames/godot_luaAPI/workflows/windows/main/windows-template.zip)
+- [🎨 Windows Template Debug](https://nightly.link/WeaselGames/godot_luaAPI/workflows/windows/main/windows-template-debug.zip)
+- [🍎 MacOS Editor](https://nightly.link/WeaselGames/godot_luaAPI/workflows/macos/main/macos-editor.zip)
+- [🍎 MacOS Templates](https://nightly.link/WeaselGames/godot_luaAPI/workflows/macos/main/macos-template.zip)
+- [🍎 MacOS Templates Debug](https://nightly.link/WeaselGames/godot_luaAPI/workflows/macos/main/macos-template-debug.zip)
 
 TODO
 -----
@@ -74,9 +74,9 @@ TODO
 Compiling
 ------------
 This build is for godot 4.0.0-betaX. X being the latest version. Will not be supporting older alpha builds.
-- Start by cloning the Godot 4.0.0-alpha [source](https://github.com/godotengine/godot) with this command `git clone https://github.com/godotengine/godot`
+- Start by cloning the Godot 4.0.0-beta [source](https://github.com/godotengine/godot) with this command `git clone https://github.com/godotengine/godot`
 
-- Next change directories into the modules folder and clone this repo into a folder named luaAPI with this command `git clone --recurse-submodules https://github.com/WeaselGames/godot_luaAPI luaAPI`
+- Next change directories into the modules folder and clone this repo into a folder named luaAPI with this command `git clone --recurse-submodules https://github.com/WeaselGames/godot_luaAPI luaAPI`. Make sure to use --recurse-submodules to pull the submodules aswell.
 
 - Now you can follow the Godot build instructions on their [site](https://docs.godotengine.org/en/latest/development/compiling/).
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Art created by [Alex](https://www.instagram.com/redheadalex1)
 
 ***WARNING!!!*** this is an **alpha** version of the module made for Godot v4-beta. Please see the branch [v1.1-stable](https://github.com/WeaselGames/lua/tree/v1.1-stable) for godot v3.x.
 
-This is a Godot engine module that adds lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This module provides no functinality to program your game out of the box. This module allows you to create custom modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
+This is a Godot engine module that adds lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This module provides no functionality to program your game out of the box. This module allows you to create custom modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
 
 If you are looking to make your game using lua instead of creating a modding API check out one of these modules
 - [luascript](https://github.com/perbone/luascript) by [perbone](https://github.com/perbone)
@@ -76,7 +76,7 @@ Compiling
 This build is for godot 4.0.0-betaX. X being the latest version. Will not be supporting older alpha builds.
 - Start by cloning the Godot 4.0.0-beta [source](https://github.com/godotengine/godot) with this command `git clone https://github.com/godotengine/godot`
 
-- Next change directories into the modules folder and clone this repo into a folder named luaAPI with this command `git clone --recurse-submodules https://github.com/WeaselGames/godot_luaAPI luaAPI`. Make sure to use --recurse-submodules to pull the submodules aswell.
+- Next change directories into the modules folder and clone this repo into a folder named luaAPI with this command `git clone --recurse-submodules https://github.com/WeaselGames/godot_luaAPI luaAPI`. Make sure to use --recurse-submodules to pull the submodules as well.
 
 - Now you can follow the Godot build instructions on their [site](https://docs.godotengine.org/en/latest/development/compiling/).
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ var lua: LuaAPI
 
 func test(n: int):
 	if n != 5:
-		# This will raise a error in the Lua state
+		# This will raise an error in the Lua state.
 		return LuaError.new_err("N is not 5 but is %s" % n, LuaError.ERR_RUNTIME)
 	return n+5
 
@@ -184,7 +184,7 @@ func _ready():
 	lua = LuaAPI.new()
 	lua.push_variant(test, "test")
 	# Most methods return a LuaError
-	# Calling test with a type that is not a int would also raise a error.
+	# Calling test with a type that is not a int would also raise an error.
 	var err = lua.do_string("test(6)")
 	# The static method is_err will check that the variant type is LuaError and that the errorType is not LuaError.ERR_NONE
 	if err is LuaError:
@@ -200,7 +200,7 @@ var lua: LuaAPI
 
 func _ready():
 	lua = LuaAPI.new()
-	# All libraries are avalible. Use OS and IO at your own risk.
+	# All libraries are available. Use OS and IO at your own risk.
 	lua.bind_libs(["base", "table", "string"])
 ```
 <br />
@@ -213,7 +213,7 @@ var lua: LuaAPI
 
 class Player:
 	var pos = Vector2(0, 0)
-	# If lua_funcs is not defined or returns a empty array, all functions will be aval
+	# If lua_funcs is not defined or returns a empty array, all functions will be aval.
 	func lua_funcs():
 		return ["move_forward"]
 	# lua_fields behaves the same as lua_funcs but for fields.

--- a/README.md
+++ b/README.md
@@ -17,29 +17,29 @@ Art created by [Alex](https://www.instagram.com/redheadalex1)
 
 ***WARNING!!!*** this is an **alpha** version of the module made for Godot v4-beta. Please see the branch [v1.1-stable](https://github.com/WeaselGames/lua/tree/v1.1-stable) for godot v3.x.
 
-This is a Godot engine module that adds lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This module provides no functionality to program your game out of the box. This module allows you to create custom modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
+This is a Godot engine module that adds Lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This module provides no functionality to program your game out of the box. This module allows you to create custom modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
 
-If you are looking to make your game using lua instead of creating a modding API check out one of these modules
+If you are looking to make your game using Lua instead of creating a modding API check out one of these modules
 - [luascript](https://github.com/perbone/luascript) by [perbone](https://github.com/perbone)
 - [godot-lua-pluginscript](https://github.com/gilzoide/godot-lua-pluginscript) by [gilzoide](https://github.com/gilzoide)
 
 
 To use you can either [Compile from source](#compiling) or you can download one of the [nightly builds](#nightly-builds).
 
-By default the lua print function is set to print to the GDEditor console. This can be changed by exposing your own print function as it will overwrite the existing one.
+By default the Lua print function is set to print to the GDEditor console. This can be changed by exposing your own print function as it will overwrite the existing one.
 
 Features
 --------------------------------
-- Run lua directly from a string or a text file.
+- Run Lua directly from a string or a text file.
 - Push any Variant as a global.
-- Call lua functions from GDScript.
-- Choose which libraries you want lua to have access to.
-- Custom LuaCallable type which allows you to get a lua function as a Callable. See [examples](#examples) below.
-- LuaError type which is used to report any errors this module or lua run into.
-- LuaThread type which creates a lua thread. This is not a OS thread but a coroutine. 
+- Call Lua functions from GDScript.
+- Choose which libraries you want Lua to have access to.
+- Custom LuaCallable type which allows you to get a Lua function as a Callable. See [examples](#examples) below.
+- LuaError type which is used to report any errors this module or Lua run into.
+- LuaThread type which creates a Lua thread. This is not a OS thread but a coroutine. 
 - Object passed as userdata. See [examples](#examples) below.
-- Objects can override most of the lua metamethods. I.E. __index by defining a function with the same name.
-- Callables passed as userdata, which allows you to push a Callable as a lua function. see [examples](#examples) below.
+- Objects can override most of the Lua metamethods. I.E. __index by defining a function with the same name.
+- Callables passed as userdata, which allows you to push a Callable as a Lua function. See [examples](#examples) below.
 - Basic types are passed as userdata (currently: Vector2, Vector3, Color, Rect2, Plane) with a useful metatable. This means you can do things like:  
 ```lua
 local v1 = Vector2(1,2)
@@ -47,7 +47,7 @@ local v2 = Vector2(100.52,100.83)
 v2 = v2.floor()
 print(v2.x) -- "100"
 print(v1+v2) -- "(101,102)"
-change_my_sprite_color(Color(1,0,0,1)) -- if "change_my_sprite_color" was exposed, in GDScript it will receive a Color variant.
+change_my_sprite_color(Color(1,0,0,1)) -- If "change_my_sprite_color" was exposed, in GDScript it will receive a Color variant.
 ```
 
 If a feature is missing that you would like to see feel free to create a [Feature Request](https://github.com/WeaselGames/lua/issues/new?assignees=&labels=feature%20request&template=feature_request.md&title=) or submit a PR 
@@ -84,7 +84,7 @@ Examples
 ------------
 If you are looking for more in depth information please refer to our [wiki](https://github.com/WeaselGames/godot_luaAPI/wiki).
 
-**Running lua from a string:**
+**Running Lua from a string:**
 ```gdscript
 extends Node2D
 
@@ -96,7 +96,7 @@ func _ready():
 ```
 <br />
 
-**Running lua from a file:**
+**Running Lua from a file:**
 ```gdscript
 extends Node2D
 
@@ -122,7 +122,7 @@ func _ready():
 ```
 <br />
 
-**Exposing a GDScript function to lua:**
+**Exposing a GDScript function to Lua:**
 ```gdscript
 extends Node2D
 
@@ -140,7 +140,7 @@ func _ready():
 ```
 <br />
 
-**Calling a lua function from GDScript:**
+**Calling a Lua function from GDScript:**
 ```gdscript
 extends Node2D
 
@@ -150,7 +150,7 @@ func _ready():
 	lua = LuaAPI.new()
 	lua.do_file("user://luaFile.lua")
 	if( lua.function_exists("set_colors")):
-		# call_function will return a Variant if lua returns nothing the value will be null
+		# call_function will return a Variant if Lua returns nothing the value will be null
 		var value = lua.call_function("set_colors", ["red", "blue"])
 		if value != null:
 			print(value)
@@ -158,7 +158,7 @@ func _ready():
 			print("no value returned")	
 		
 	if( lua.function_exists("set_location")):
-		# Assumeing lua defines a function set_location this will return a callable which you can use ot invoke the lua function
+		# Assuming Lua defines a function set_location this will return a callable which you can use to invoke the Lua function.
 		var set_location = lua.pull_variant("set_location")
 		var value2 = set_location.call(Vector2(1, 1))
 		if value2 != null:
@@ -176,7 +176,7 @@ var lua: LuaAPI
 
 func test(n: int):
 	if n != 5:
-		# This will raise a error in the lua state
+		# This will raise a error in the Lua state
 		return LuaError.new_err("N is not 5 but is %s" % n, LuaError.ERR_RUNTIME)
 	return n+5
 
@@ -186,7 +186,7 @@ func _ready():
 	# Most methods return a LuaError
 	# calling test with a type that is not a int would also raise a error.
 	var err = lua.do_string("test(6)")
-	# the static method is_err will check that the variant type is LuaError and that the errorType is not LuaError.ERR_NONE
+	# The static method is_err will check that the variant type is LuaError and that the errorType is not LuaError.ERR_NONE
 	if err is LuaError:
 		print("ERROR %d: " % err.type + err.msg)
 ```
@@ -200,7 +200,7 @@ var lua: LuaAPI
 
 func _ready():
 	lua = LuaAPI.new()
-	#all libraries are avalible. Use OS and IO at your own risk.
+	# All libraries are avalible. Use OS and IO at your own risk.
 	lua.bind_libs(["base", "table", "string"])
 ```
 <br />
@@ -213,10 +213,10 @@ var lua: LuaAPI
 
 class Player:
 	var pos = Vector2(0, 0)
-	#If lua_funcs is not defined or returns a empty array, all functions will be aval
+	# If lua_funcs is not defined or returns a empty array, all functions will be aval
 	func lua_funcs():
 		return ["move_forward"]
-	#lua_fields behaves the same as lua_funcs but for fields.
+	# lua_fields behaves the same as lua_funcs but for fields.
 	func lua_fields():
 		return ["pos"]
 	func move_forward():
@@ -256,7 +256,7 @@ class Player:
 func _ready():
 	lua = LuaAPI.new()
 	lua.expose_constructor(Player, "Player")
-	var err = lua.do_string("player = Player() print(player.pos.x)  player.move_forward() -- this will cause our custom error ")
+	var err = lua.do_string("player = Player() print(player.pos.x)  player.move_forward() -- This will cause our custom error ")
 	if err is LuaError:
 		print(err.msg)
 	var player = lua.pull_variant("player")
@@ -271,11 +271,11 @@ var thread: LuaThread
 	
 func _ready():
 	lua = LuaAPI.new()
-	# Despite the name this is not like a OS thread. It is a coroutine
+	# Despite the name, this is not like a OS thread. It is a coroutine.
 	thread = LuaThread.new_thread(lua)
 	thread.load_string("
 	while true do
-		-- yield is exposed to lua when the thread is bound.
+		-- yield is exposed to Lua when the thread is bound.
 		yield(1)
 		print('Hello world!')
 	end
@@ -287,7 +287,7 @@ func _process(delta):
 	timeSince += delta
 	if thread.is_done() || timeSince <= yieldTime:
 		return
-	# thread.resume will either return a LuaError or a Array.
+	# thread.resume will either return a LuaError or an Array.
 	var ret = thread.resume()
 	if ret is LuaError:
 		print("ERROR %d: " % ret.type + ret.msg)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ func _ready():
 	lua = LuaAPI.new()
 	lua.push_variant(test, "test")
 	# Most methods return a LuaError
-	# calling test with a type that is not a int would also raise a error.
+	# Calling test with a type that is not a int would also raise a error.
 	var err = lua.do_string("test(6)")
 	# The static method is_err will check that the variant type is LuaError and that the errorType is not LuaError.ERR_NONE
 	if err is LuaError:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Art created by [Alex](https://www.instagram.com/redheadalex1)
 
 This is a Godot engine module that adds Lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This module provides no functionality to program your game out of the box. This module allows you to create custom modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
 
-If you are looking to make your game using Lua instead of creating a modding API check out one of these modules
+If you are looking to make your game using Lua instead of creating a modding API check out one of these projects
 - [luascript](https://github.com/perbone/luascript) by [perbone](https://github.com/perbone)
 - [godot-lua-pluginscript](https://github.com/gilzoide/godot-lua-pluginscript) by [gilzoide](https://github.com/gilzoide)
 
@@ -299,6 +299,6 @@ Contributing And Feature Requests
 ---------------
 All contributions are welcome, if you would like to contribute submit a PR.
 <br />
-Additionally if you do not have the time and or the knowledge you can create a [Feature Request](https://github.com/WeaselGames/lua/issues/new?assignees=&labels=feature%20request&template=feature_request.md&title=)
+Additionally if you do not have the time and or the knowledge you can create a [Feature Request](https://github.com/WeaselGames/lua/issues/new?assignees=&labels=feature%20request&template=feature_request.md&title=).
 
 [![lua logo](https://www.lua.org/images/powered-by-lua.gif)](https://www.lua.org/)

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -169,11 +169,11 @@ LuaError* LuaState::pushVariant(Variant var, lua_State* state) {
                 Variant value = array[i];
 
                 LuaError* err = pushVariant(key, state);
-                if (err == nullptr)
+                if (err != nullptr)
                     return err;
                 
                 err = pushVariant(value, state);
-                if (err == nullptr)
+                if (err != nullptr)
                     return err;
 
                 lua_settable(state, -3);
@@ -189,11 +189,11 @@ LuaError* LuaState::pushVariant(Variant var, lua_State* state) {
                 Variant value = dict[key];
                 
                 LuaError* err = pushVariant(key, state);
-                if (err == nullptr)
+                if (err != nullptr)
                     return err;
                 
                 err = pushVariant(value, state);
-                if (err == nullptr)
+                if (err != nullptr)
                     return err;
 
                 lua_settable(state, -3);


### PR DESCRIPTION
Fixed a bug caused by the recent changes to LuaError where we were checking err == nullptr instead of err != nullptr.
Fixed several typos in the readme as well as the nightly links.