### PR TITLE
Added support for RefCounted types via lightuserdata

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ var test = "Hello lua!"
 
 func _ready():
 	lua = LuaAPI.new()
-	lua.push_variant(test, "str")
+	lua.push_variant("str", test)
 	lua.do_string("print(str)")
 ```
 <br />
@@ -134,8 +134,8 @@ func luaAdd(a, b):
 func _ready():
 	lua = LuaAPI.new()
 	# Functions are passed the same as any other value to lua.
-	lua.push_variant(luaAdd, "add")
-	lua.push_variant(func(a, b): return a+b, "addLamda")
+	lua.push_variant("add", luaAdd)
+	lua.push_variant("addLamda", func(a, b): return a+b)
 	lua.do_string("print(add(2, 4), addLamda(3,3))")
 ```
 <br />
@@ -182,7 +182,7 @@ func test(n: int):
 
 func _ready():
 	lua = LuaAPI.new()
-	lua.push_variant(test, "test")
+	lua.push_variant("test", test)
 	# Most methods return a LuaError
 	# Calling test with a type that is not a int would also raise an error.
 	var err = lua.do_string("test(6)")
@@ -227,8 +227,8 @@ var player2: Player
 func _ready():
 	lua = LuaAPI.new()
 	player2 = Player.new()
-	lua.push_variant(func(): return player2, "getPlayer2")
-	lua.expose_constructor(Player, "Player")
+	lua.push_variant("getPlayer2", func(): return player2)
+	lua.expose_constructor("Player", Player)
 	lua.do_string("player = Player() player.move_forward() print(player.pos.x)")
 	lua.do_string("player2 = getPlayer2() player2.pos = Vector2(50, 1) print(player2.pos)")
 	var player = lua.pull_variant("player")
@@ -255,7 +255,7 @@ class Player:
 
 func _ready():
 	lua = LuaAPI.new()
-	lua.expose_constructor(Player, "Player")
+	lua.expose_constructor("Player", Player)
 	var err = lua.do_string("player = Player() print(player.pos.x)  player.move_forward() -- This will cause our custom error ")
 	if err is LuaError:
 		print(err.msg)

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ Art created by [Alex](https://www.instagram.com/redheadalex1)
 
 This is a Godot engine module that adds Lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This module provides no functionality to program your game out of the box. This module allows you to create custom modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
 
-If you are looking to make your game using Lua instead of creating a modding API check out one of these projects
+If you are looking to make your game using Lua instead of creating a modding API check out one of these projects:
 - [luascript](https://github.com/perbone/luascript) by [perbone](https://github.com/perbone)
 - [godot-lua-pluginscript](https://github.com/gilzoide/godot-lua-pluginscript) by [gilzoide](https://github.com/gilzoide)
-
+<br />
 
 To use you can either [Compile from source](#compiling) or you can download one of the [nightly builds](#nightly-builds).
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ var lua: LuaAPI
 func _ready():
 	lua = LuaAPI.new()
 	lua.do_file("user://luaFile.lua")
-	if( lua.function_exists("set_colors")):
+	if(lua.function_exists("set_colors")):
 		# call_function will return a Variant if Lua returns nothing the value will be null
 		var value = lua.call_function("set_colors", ["red", "blue"])
 		if value != null:
@@ -157,7 +157,7 @@ func _ready():
 		else:
 			print("no value returned")	
 		
-	if( lua.function_exists("set_location")):
+	if(lua.function_exists("set_location")):
 		# Assuming Lua defines a function set_location this will return a callable which you can use to invoke the Lua function.
 		var set_location = lua.pull_variant("set_location")
 		var value2 = set_location.call(Vector2(1, 1))

--- a/docs/LuaAPI.xml
+++ b/docs/LuaAPI.xml
@@ -14,14 +14,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="call_function">
-			<return type="Variant" />
-			<param index="0" name="LuaFunctionName" type="String" />
-			<param index="1" name="Args" type="Array" />
-			<description>
-				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua. You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code]. This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null.
-			</description>
-		</method>
 		<method name="do_file">
 			<return type="LuaError" />
 			<param index="0" name="File" type="String" />
@@ -38,8 +30,8 @@
 		</method>
 		<method name="expose_constructor">
 			<return type="LuaError" />
-			<param index="0" name="Object" type="Object" />
-			<param index="1" name="LuaConstructorName" type="String" />
+			<param index="0" name="LuaConstructorName" type="String" />
+			<param index="1" name="Object" type="Object" />
 			<description>
 				Accepts any object that has a new() method. Allows lua to call the contructor aka the new() method. Exposed as a global with the given name.
 			</description>
@@ -51,6 +43,14 @@
 				Returns [code]true[/code] only if [code]LuaFunctionName[/code] is defined in current Lua's state as a function.
 			</description>
 		</method>
+		<method name="call_function">
+			<return type="Variant" />
+			<param index="0" name="LuaFunctionName" type="String" />
+			<param index="1" name="Args" type="Array" />
+			<description>
+				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua. You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code]. This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null.
+			</description>
+		</method>
 		<method name="pull_variant">
 			<return type="Variant" />
 			<param index="0" name="Name" type="String" />
@@ -60,8 +60,8 @@
 		</method>
 		<method name="push_variant">
 			<return type="LuaError" />
-			<param index="0" name="var" type="Variant" />
-			<param index="1" name="Name" type="String" />
+			<param index="0" name="Name" type="String" />
+			<param index="1" name="var" type="Variant" />
 			<description>
 				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
 			</description>

--- a/docs/LuaThread.xml
+++ b/docs/LuaThread.xml
@@ -49,5 +49,43 @@
 				Returns true if the thread is finished executing.
 			</description>
 		</method>
+		<method name="expose_constructor">
+			<return type="LuaError" />
+			<param index="0" name="LuaConstructorName" type="String" />
+			<param index="1" name="Object" type="Object" />
+			<description>
+				Accepts any object that has a new() method. Allows lua to call the contructor aka the new() method. Exposed as a global with the given name.
+			</description>
+		</method>
+		<method name="function_exists">
+			<return type="bool" />
+			<param index="0" name="LuaFunctionName" type="String" />
+			<description>
+				Returns [code]true[/code] only if [code]LuaFunctionName[/code] is defined in current Lua's state as a function.
+			</description>
+		</method>
+		<method name="call_function">
+			<return type="Variant" />
+			<param index="0" name="LuaFunctionName" type="String" />
+			<param index="1" name="Args" type="Array" />
+			<description>
+				Calls a function inside current Lua state. This can be either a exposed function or a function defined with with lua. You may want to check if the function actually exists with [code]function_exists(LuaFunctionName)[/code]. This function supports 1 return value from lua. It will be returned as a variant and if lua returns no value it will be null.
+			</description>
+		</method>
+		<method name="pull_variant">
+			<return type="Variant" />
+			<param index="0" name="Name" type="String" />
+			<description>
+				Will pull a copy of a global Variant from lua.
+			</description>
+		</method>
+		<method name="push_variant">
+			<return type="LuaError" />
+			<param index="0" name="Name" type="String" />
+			<param index="1" name="var" type="Variant" />
+			<description>
+				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -4,7 +4,7 @@
 LuaAPI::LuaAPI() {
     lState = luaL_newstate();
 	// Createing lua state instance
-	state.setState(lState, true);
+	state.setState(lState, Ref<RefCounted>(this), true);
 }
 
 LuaAPI::~LuaAPI() {

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -40,11 +40,13 @@ void LuaAPI::addOwnedObject(void* luaPtr, Variant* obj) {
 
 // Adds the pointer to a object now owned by lua for cleanup later
 void LuaAPI::removeOwnedObject(Variant* obj) {
-    ownedObjects.erase(obj);
+    memdelete(ownedObjects[(void*)obj]);
+    ownedObjects[(void*)obj] = nullptr;
 }
 
 // Adds the pointer to a object now owned by lua for cleanup later
 void LuaAPI::removeOwnedObject(void* luaPtr) {
+    memdelete(ownedObjects[luaPtr]);
     ownedObjects[luaPtr] = nullptr;
 }
 

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -17,11 +17,11 @@ void LuaAPI::_bind_methods() {
     ClassDB::bind_method(D_METHOD("do_string", "Code"), &LuaAPI::doString);
 
     ClassDB::bind_method(D_METHOD("bind_libs", "Array"),&LuaAPI::bindLibs);
-    ClassDB::bind_method(D_METHOD("push_variant", "var", "Name"), &LuaAPI::pushGlobalVariant);
+    ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
     ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
-    ClassDB::bind_method(D_METHOD("expose_constructor", "Object", "LuaConstructorName"), &LuaAPI::exposeObjectConstructor);
+    ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
     ClassDB::bind_method(D_METHOD("call_function", "LuaFunctionName", "Args"), &LuaAPI::callFunction);
-    ClassDB::bind_method(D_METHOD("function_exists","LuaFunctionName"), &LuaAPI::luaFunctionExists);
+    ClassDB::bind_method(D_METHOD("function_exists", "LuaFunctionName"), &LuaAPI::luaFunctionExists);
 }
 
 // Calls LuaState::bindLibs()
@@ -45,13 +45,13 @@ Variant LuaAPI::callFunction(String functionName, Array args) {
 }
 
 // Calls LuaState::pushGlobalVariant()
-LuaError* LuaAPI::pushGlobalVariant(Variant var, String name) {
-    return state.pushGlobalVariant(var, name);
+LuaError* LuaAPI::pushGlobalVariant(String name, Variant var) {
+    return state.pushGlobalVariant(name, var);
 }
 
 // Calls LuaState::exposeObjectConstructor()
-LuaError* LuaAPI::exposeObjectConstructor(Object* obj, String name) {
-    return state.exposeObjectConstructor(obj, name);
+LuaError* LuaAPI::exposeObjectConstructor(String name, Object* obj) {
+    return state.exposeObjectConstructor(name, obj);
 }
 
 // addFile() calls luaL_loadfille with the absolute file path

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -8,6 +8,9 @@ LuaAPI::LuaAPI() {
 }
 
 LuaAPI::~LuaAPI() {
+    for (void* ptr : ownedObjects) {
+        memdelete(ptr);
+    }
     lua_close(lState);
 }
 
@@ -27,6 +30,11 @@ void LuaAPI::_bind_methods() {
 // Calls LuaState::bindLibs()
 void LuaAPI::bindLibs(Array libs) {
     state.bindLibs(libs);
+}
+
+// Adds the pointer to a object now owned by lua for cleanup later
+void LuaAPI::addOwnedObject(void* obj) {
+    ownedObjects.push_back(obj);
 }
 
 // Calls LuaState::luaFunctionExists()

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -8,8 +8,8 @@ LuaAPI::LuaAPI() {
 }
 
 LuaAPI::~LuaAPI() {
-    for (void* ptr : ownedObjects) {
-        memdelete(ptr);
+    for (Variant* obj : ownedObjects) {
+        memdelete(obj);
     }
     lua_close(lState);
 }
@@ -19,7 +19,7 @@ void LuaAPI::_bind_methods() {
     ClassDB::bind_method(D_METHOD("do_file", "File"), &LuaAPI::doFile);
     ClassDB::bind_method(D_METHOD("do_string", "Code"), &LuaAPI::doString);
 
-    ClassDB::bind_method(D_METHOD("bind_libs", "Array"),&LuaAPI::bindLibs);
+    ClassDB::bind_method(D_METHOD("bind_libs", "Array"), &LuaAPI::bindLibs);
     ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
     ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
     ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
@@ -33,7 +33,7 @@ void LuaAPI::bindLibs(Array libs) {
 }
 
 // Adds the pointer to a object now owned by lua for cleanup later
-void LuaAPI::addOwnedObject(void* obj) {
+void LuaAPI::addOwnedObject(Variant* obj) {
     ownedObjects.push_back(obj);
 }
 

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -8,8 +8,9 @@ LuaAPI::LuaAPI() {
 }
 
 LuaAPI::~LuaAPI() {
-    for (Variant* obj : ownedObjects) {
-        memdelete(obj);
+    for (auto &[key, val] : ownedObjects) {
+        if (val != nullptr)
+            memdelete(val);
     }
     lua_close(lState);
 }
@@ -33,9 +34,20 @@ void LuaAPI::bindLibs(Array libs) {
 }
 
 // Adds the pointer to a object now owned by lua for cleanup later
-void LuaAPI::addOwnedObject(Variant* obj) {
-    ownedObjects.push_back(obj);
+void LuaAPI::addOwnedObject(void* luaPtr, Variant* obj) {
+    ownedObjects[luaPtr] = obj;
 }
+
+// Adds the pointer to a object now owned by lua for cleanup later
+void LuaAPI::removeOwnedObject(Variant* obj) {
+    ownedObjects.erase(obj);
+}
+
+// Adds the pointer to a object now owned by lua for cleanup later
+void LuaAPI::removeOwnedObject(void* luaPtr) {
+    ownedObjects[luaPtr] = nullptr;
+}
+
 
 // Calls LuaState::luaFunctionExists()
 bool LuaAPI::luaFunctionExists(String functionName) {

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -9,7 +9,7 @@
 #include <luaState.h>
 
 #include <string>
-#include <vector>
+#include <map>
 
 
 class LuaAPI : public RefCounted {
@@ -23,7 +23,9 @@ class LuaAPI : public RefCounted {
         ~LuaAPI();
 
         void bindLibs(Array libs);
-        void addOwnedObject(Variant* obj);
+        void addOwnedObject(void* luaPtr, Variant* obj);
+        void removeOwnedObject(Variant* obj);
+        void removeOwnedObject(void* luaPtr);
 
         bool luaFunctionExists(String functionName);
 
@@ -41,7 +43,7 @@ class LuaAPI : public RefCounted {
     private:
         LuaState state;
         lua_State* lState;
-        std::vector<Variant*> ownedObjects;
+        std::map<void*, Variant*> ownedObjects;
         LuaError* execute(int handlerIndex);
 };
 

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -9,6 +9,7 @@
 #include <luaState.h>
 
 #include <string>
+#include <vector>
 
 
 class LuaAPI : public RefCounted {
@@ -22,6 +23,7 @@ class LuaAPI : public RefCounted {
         ~LuaAPI();
 
         void bindLibs(Array libs);
+        void addOwnedObject(void* obj);
 
         bool luaFunctionExists(String functionName);
 
@@ -39,6 +41,7 @@ class LuaAPI : public RefCounted {
     private:
         LuaState state;
         lua_State* lState;
+        std::vector<void*> ownedObjects;
         LuaError* execute(int handlerIndex);
 };
 

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -30,8 +30,8 @@ class LuaAPI : public RefCounted {
 
         LuaError* doFile(String fileName);
         LuaError* doString(String code);
-        LuaError* pushGlobalVariant(Variant var, String name);
-        LuaError* exposeObjectConstructor(Object* obj, String name);
+        LuaError* pushGlobalVariant(String name, Variant var);
+        LuaError* exposeObjectConstructor(String name, Object* obj);
         
         lua_State* newThread();
         lua_State* getState();

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -23,7 +23,7 @@ class LuaAPI : public RefCounted {
         ~LuaAPI();
 
         void bindLibs(Array libs);
-        void addOwnedObject(void* obj);
+        void addOwnedObject(Variant* obj);
 
         bool luaFunctionExists(String functionName);
 
@@ -41,7 +41,7 @@ class LuaAPI : public RefCounted {
     private:
         LuaState state;
         lua_State* lState;
-        std::vector<void*> ownedObjects;
+        std::vector<Variant*> ownedObjects;
         LuaError* execute(int handlerIndex);
 };
 

--- a/src/classes/luaCallable.cpp
+++ b/src/classes/luaCallable.cpp
@@ -49,14 +49,14 @@ void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_r
 
 	// Push all the argument on to the stack
 	for (int i = 0; i < p_argcount; i++) {
-		LuaState::pushVariant(*p_arguments[i], state);
+		LuaState::pushVariant(state, *p_arguments[i]);
 	}
 
 	// execute the function using a protected call.
 	int ret = lua_pcall(state, p_argcount, 1, 0);
     if (ret != LUA_OK) {
-        r_return_value = LuaState::handleError(ret, state);
-    } else r_return_value = LuaState::getVariant(1, state, obj);
+        r_return_value = LuaState::handleError(state, ret);
+    } else r_return_value = LuaState::getVariant(state, 1, obj);
 
 	lua_pop(state, 1);
 }

--- a/src/classes/luaThread.cpp
+++ b/src/classes/luaThread.cpp
@@ -58,7 +58,7 @@ void LuaThread::bind(Ref<LuaAPI> lua) {
     shouldCloseParent=false;
     parentState = lua->getState();
     tState = lua->newThread();
-    state.setState(tState, false);
+    state.setState(tState, Ref<RefCounted>(this), false);
     
     // register the yield method
     lua_register(tState, "yield", luaYield);

--- a/src/classes/luaThread.cpp
+++ b/src/classes/luaThread.cpp
@@ -53,7 +53,7 @@ LuaThread* LuaThread::newThread(Ref<LuaAPI> lua) {
 
 // binds the thread to a lua object
 void LuaThread::bind(Ref<LuaAPI> lua) {
-    parentState = lua->getState();
+    parent = lua;
     tState = lua->newThread();
     state.setState(tState, Ref<RefCounted>(this), false);
     

--- a/src/classes/luaThread.h
+++ b/src/classes/luaThread.h
@@ -38,6 +38,7 @@ class LuaThread : public RefCounted {
         static int luaYield(lua_State *state);
     private:
         LuaState state;
+        Ref<LuaAPI> parent;
         lua_State* tState;
         lua_State* parentState;
         bool done;

--- a/src/classes/luaThread.h
+++ b/src/classes/luaThread.h
@@ -26,8 +26,8 @@ class LuaThread : public RefCounted {
         bool luaFunctionExists(String functionName);
 
         LuaError* loadFile(String fileName);
-        LuaError* pushGlobalVariant(Variant var, String name);
-        LuaError* exposeObjectConstructor(Object* obj, String name);
+        LuaError* pushGlobalVariant(String name, Variant var);
+        LuaError* exposeObjectConstructor(String name, Object* obj);
 
         Variant resume();
         Variant pullVariant(String name);
@@ -40,9 +40,7 @@ class LuaThread : public RefCounted {
         LuaState state;
         lua_State* tState;
         lua_State* parentState;
-        LuaError* handleError(int lua_error) const;
         bool done;
-        bool shouldCloseParent = false;
 };
 
 #endif

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -247,9 +247,7 @@ LuaError* LuaState::pushVariant(Variant var, lua_State* state) {
                 luaL_setmetatable(state, "mt_RefCounted");
                 break;  
             }
-
             
-
             void* userdata = (Variant*)lua_newuserdata(state, sizeof(Variant));
             memcpy(userdata, (void*)&var, sizeof(Variant));
             luaL_setmetatable(state, "mt_Object");

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -18,7 +18,7 @@ void LuaState::setState(lua_State *L, Ref<RefCounted> obj, bool bindAPI) {
     createPlaneMetatable();     // "mt_Plane"
     createObjectMetatable();    // "mt_Object"
     createCallableMetatable();  // "mt_Callable"
-    createRefCountedMetatable(); // "mt_RefCounted"
+    createRefCountedMetatable();// "mt_RefCounted"
 
     // Exposing basic types constructors
 	exposeConstructors();
@@ -247,7 +247,7 @@ LuaError* LuaState::pushVariant(Variant var, lua_State* state) {
                 luaL_setmetatable(state, "mt_RefCounted");
                 break;  
             }
-            
+
             void* userdata = (Variant*)lua_newuserdata(state, sizeof(Variant));
             memcpy(userdata, (void*)&var, sizeof(Variant));
             luaL_setmetatable(state, "mt_Object");

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -10,6 +10,11 @@ void LuaState::setState(lua_State *L, Ref<RefCounted> obj, bool bindAPI) {
     // push our custom print function so by default it prints to the GDConsole.
     lua_register(L, "print", luaPrint);
 
+    // saving the object into registry
+	lua_pushstring(L, "__OBJECT");
+	lua_pushlightuserdata(L, obj.ptr());
+	lua_rawset(L, LUA_REGISTRYINDEX);
+
     // Creating basic types metatables and saving them in registry
 	createVector2Metatable();   // "mt_Vector2"
 	createVector3Metatable();   // "mt_Vector3"

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -20,15 +20,15 @@ class LuaState {
         Variant callFunction(String functionName, Array args);
 
         LuaError* pushVariant(Variant var) const;
-        LuaError* pushGlobalVariant(Variant var, String name);
-        LuaError* exposeObjectConstructor(Object* obj, String name);
+        LuaError* pushGlobalVariant(String name, Variant var);
+        LuaError* exposeObjectConstructor(String name, Object* obj);
         LuaError* handleError(int lua_error) const;
         
-        static LuaError* pushVariant(Variant var, lua_State* state);
-        static LuaError* handleError(int lua_error, lua_State* state);
+        static LuaError* pushVariant(lua_State* state, Variant var);
+        static LuaError* handleError(lua_State* state, int lua_error);
         static LuaError* handleError(const StringName &func, Callable::CallError error, const Variant** p_arguments, int argc);
 
-        static Variant getVariant(int index, lua_State* L, Ref<RefCounted> obj);
+        static Variant getVariant(lua_State* state, int index, Ref<RefCounted> obj);
 
         // Lua functions
         static int luaErrorHandler(lua_State* state);

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -8,7 +8,7 @@
 
 class LuaState {
     public:
-        void setState(lua_State* state, bool bindAPI);
+        void setState(lua_State* state, Ref<RefCounted> obj, bool bindAPI);
         void bindLibs(Array libs);
 
         bool luaFunctionExists(String functionName);
@@ -35,6 +35,7 @@ class LuaState {
         static int luaPrint(lua_State* state);
         static int luaExposedFuncCall(lua_State* state);
         static int luaUserdataFuncCall(lua_State* state);
+        static int luaLightUserdataFuncCall(lua_State* state);
         static int luaCallableCall(lua_State* state);
     private:
         lua_State *L = nullptr;
@@ -47,6 +48,7 @@ class LuaState {
         void createRect2Metatable();
         void createPlaneMetatable();
         void createObjectMetatable();
+        void createRefCountedMetatable();
         void createCallableMetatable();
 };
 

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -17,11 +17,11 @@ static std::map<void*, Variant*> luaObjects;
      lua_rawget(inner_state,LUA_REGISTRYINDEX);                               \
      Ref<RefCounted> OBJ = (Ref<RefCounted>) lua_touserdata(inner_state, -1); \
      lua_pop(inner_state, 1);                                                 \
-     Variant arg1 = LuaState::getVariant(1, inner_state, OBJ);                \
-     Variant arg2 = LuaState::getVariant(2, inner_state, OBJ);                \
-     Variant arg3 = LuaState::getVariant(3, inner_state, OBJ);                \
-     Variant arg4 = LuaState::getVariant(4, inner_state, OBJ);                \
-     Variant arg5 = LuaState::getVariant(5, inner_state, OBJ);                \
+     Variant arg1 = LuaState::getVariant(inner_state, 1, OBJ);                \
+     Variant arg2 = LuaState::getVariant(inner_state, 2, OBJ);                \
+     Variant arg3 = LuaState::getVariant(inner_state, 3, OBJ);                \
+     Variant arg4 = LuaState::getVariant(inner_state, 4, OBJ);                \
+     Variant arg5 = LuaState::getVariant(inner_state, 5, OBJ);                \
      _f_                                                                      \
 }
  
@@ -31,7 +31,7 @@ lua_pushcfunction(lua_state, LUA_LAMBDA_TEMPLATE(_f_)); \
 lua_settable(lua_state, metatable_index-2);
 
 // Expose the contructor for a object to lua
-LuaError* LuaState::exposeObjectConstructor(Object* obj, String name) {
+LuaError* LuaState::exposeObjectConstructor(String name, Object* obj) {
     // Make sure we are able to call new
     if (!obj->has_method("new")) {
         return LuaError::newErr("during \"LuaState::exposeObjectConstructor\" method 'new' does not exist.", LuaError::ERR_RUNTIME);
@@ -68,9 +68,9 @@ void LuaState::exposeConstructors() {
     lua_pushcfunction(L,LUA_LAMBDA_TEMPLATE({
         int argc = lua_gettop(inner_state);
         if (argc == 0) {
-            LuaState::pushVariant(Vector2(), inner_state);
+            LuaState::pushVariant(inner_state, Vector2());
         } else {
-            LuaState::pushVariant(Vector2(arg1.operator double(), arg2.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Vector2(arg1.operator double(), arg2.operator double()));
         }
         return 1;
     }));
@@ -79,9 +79,9 @@ void LuaState::exposeConstructors() {
     lua_pushcfunction(L,LUA_LAMBDA_TEMPLATE({
         int argc = lua_gettop(inner_state);
         if (argc == 0) {
-            LuaState::pushVariant(Vector3(), inner_state);
+            LuaState::pushVariant(inner_state, Vector3());
         } else {
-            LuaState::pushVariant(Vector3(arg1.operator double(), arg2.operator double(), arg3.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Vector3(arg1.operator double(), arg2.operator double(), arg3.operator double()));
         }
         return 1;
     }));
@@ -90,11 +90,11 @@ void LuaState::exposeConstructors() {
     lua_pushcfunction(L,LUA_LAMBDA_TEMPLATE({
         int argc = lua_gettop(inner_state);
         if (argc == 3) {
-            LuaState::pushVariant(Color(arg1.operator double(), arg2.operator double(), arg3.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Color(arg1.operator double(), arg2.operator double(), arg3.operator double()));
         } else if (argc == 4) {
-            LuaState::pushVariant(Color(arg1.operator double(), arg2.operator double(), arg3.operator double(), arg4.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Color(arg1.operator double(), arg2.operator double(), arg3.operator double(), arg4.operator double()));
         } else {
-            LuaState::pushVariant(Color(), inner_state);
+            LuaState::pushVariant(inner_state, Color());
         }
         return 1;
     }));
@@ -103,11 +103,11 @@ void LuaState::exposeConstructors() {
     lua_pushcfunction(L,LUA_LAMBDA_TEMPLATE({
         int argc = lua_gettop(inner_state);
         if (argc == 2) {
-            LuaState::pushVariant(Rect2(arg1.operator Vector2(), arg2.operator Vector2()), inner_state);
+            LuaState::pushVariant(inner_state, Rect2(arg1.operator Vector2(), arg2.operator Vector2()));
         } else if (argc == 4) {
-            LuaState::pushVariant(Rect2(arg1.operator double(), arg2.operator double(), arg3.operator double(), arg4.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Rect2(arg1.operator double(), arg2.operator double(), arg3.operator double(), arg4.operator double()));
         } else {
-            LuaState::pushVariant(Rect2(), inner_state);
+            LuaState::pushVariant(inner_state, Rect2());
         }
         return 1;
     }));
@@ -116,11 +116,11 @@ void LuaState::exposeConstructors() {
     lua_pushcfunction(L, LUA_LAMBDA_TEMPLATE({
         int argc = lua_gettop(inner_state);
         if (argc == 4) {
-            LuaState::pushVariant(Plane(arg1.operator double(), arg2.operator double(), arg3.operator double(), arg4.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Plane(arg1.operator double(), arg2.operator double(), arg3.operator double(), arg4.operator double()));
         } else if (argc == 3) {
-            LuaState::pushVariant(Plane(arg1.operator Vector3(), arg2.operator Vector3(), arg3.operator Vector3()), inner_state);
+            LuaState::pushVariant(inner_state, Plane(arg1.operator Vector3(), arg2.operator Vector3(), arg3.operator Vector3()));
         } else {
-            LuaState::pushVariant(Plane(arg1.operator Vector3(), arg1.operator double()), inner_state);
+            LuaState::pushVariant(inner_state, Plane(arg1.operator Vector3(), arg1.operator double()));
         }
         return 1;
     }));
@@ -135,12 +135,12 @@ void LuaState::createVector2Metatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         if (arg1.has_method(arg2)) {
             lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
-            LuaState::pushVariant(arg2, inner_state);
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
             return 1;
         }
         
-        LuaState::pushVariant(arg1.get(arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.get(arg2));
         return 1;
     });
  
@@ -151,23 +151,23 @@ void LuaState::createVector2Metatable() {
     }); 
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__add", {
-        LuaState::pushVariant(arg1.operator Vector2() + arg2.operator Vector2(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector2() + arg2.operator Vector2());
     return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__sub", {
-        LuaState::pushVariant(arg1.operator Vector2() - arg2.operator Vector2(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector2() - arg2.operator Vector2());
     return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__mul", {
         switch(arg2.get_type()) {
             case Variant::Type::VECTOR2:
-                LuaState::pushVariant(arg1.operator Vector2() * arg2.operator Vector2(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector2() * arg2.operator Vector2());
                 return 1;
             case Variant::Type::INT:
             case Variant::Type::FLOAT:
-                LuaState::pushVariant(arg1.operator Vector2() * arg2.operator double(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector2() * arg2.operator double());
                 return 1;
             default:
                 return 0;
@@ -177,11 +177,11 @@ void LuaState::createVector2Metatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__div", {
         switch(arg2.get_type()) {
             case Variant::Type::VECTOR2:
-                LuaState::pushVariant(arg1.operator Vector2() / arg2.operator Vector2(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector2() / arg2.operator Vector2());
                 return 1;
             case Variant::Type::INT:
             case Variant::Type::FLOAT:
-                LuaState::pushVariant(arg1.operator Vector2() / arg2.operator double(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector2() / arg2.operator double());
                 return 1;
             default:
                 return 0;
@@ -189,17 +189,17 @@ void LuaState::createVector2Metatable() {
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__eq", {
-        LuaState::pushVariant(arg1.operator Vector2() == arg2.operator Vector2(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector2() == arg2.operator Vector2());
         return 1;
     });
 
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__lt", {
-        LuaState::pushVariant(arg1.operator Vector2() < arg2.operator Vector2(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector2() < arg2.operator Vector2());
         return 1;
     });
 
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__le", {
-        LuaState::pushVariant(arg1.operator Vector2() <= arg2.operator Vector2(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector2() <= arg2.operator Vector2());
         return 1;
     });
  
@@ -212,40 +212,40 @@ void LuaState::createVector3Metatable() {
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         if (arg1.has_method(arg2)) {
-            lua_pushlightuserdata(inner_state, lua_touserdata(inner_state,1));
-            LuaState::pushVariant(arg2, inner_state);
+            lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
             return 1;
         }
         
-        LuaState::pushVariant(arg1.get(arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.get(arg2));
         return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__newindex", {
         // We can't use arg1 here because we need to reference the userdata
-        ((Variant*)lua_touserdata(inner_state,1))->set(arg2, arg3);
+        ((Variant*)lua_touserdata(inner_state, 1))->set(arg2, arg3);
         return 0;
     }); 
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__add", {
-        LuaState::pushVariant(arg1.operator Vector3() + arg2.operator Vector3(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector3() + arg2.operator Vector3());
     return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__sub", {
-        LuaState::pushVariant(arg1.operator Vector3() - arg2.operator Vector3(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector3() - arg2.operator Vector3());
     return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__mul", {
         switch(arg2.get_type()) {
             case Variant::Type::VECTOR3:
-                LuaState::pushVariant(arg1.operator Vector3() * arg2.operator Vector3(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector3() * arg2.operator Vector3());
                 return 1;
             case Variant::Type::INT:
             case Variant::Type::FLOAT:
-                LuaState::pushVariant(arg1.operator Vector3() * arg2.operator double(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector3() * arg2.operator double());
                 return 1;
             default:
                 return 0;
@@ -255,11 +255,11 @@ void LuaState::createVector3Metatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__div", {
         switch(arg2.get_type()) {
             case Variant::Type::VECTOR3:
-                LuaState::pushVariant(arg1.operator Vector3() / arg2.operator Vector3(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector3() / arg2.operator Vector3());
                 return 1;
             case Variant::Type::INT:
             case Variant::Type::FLOAT:
-                LuaState::pushVariant(arg1.operator Vector3() / arg2.operator double(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Vector3() / arg2.operator double());
                 return 1;
             default:
                 return 0;
@@ -267,7 +267,7 @@ void LuaState::createVector3Metatable() {
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__eq", {
-        LuaState::pushVariant(arg1.operator Vector3() == arg2.operator Vector3(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Vector3() == arg2.operator Vector3());
         return 1;
     });
  
@@ -282,12 +282,12 @@ void LuaState::createRect2Metatable() {
         // Index was not found, so check to see if there is a matching function
         if (arg1.has_method(arg2)) {
             lua_pushlightuserdata(inner_state, lua_touserdata(inner_state,1));
-            LuaState::pushVariant(arg2, inner_state);
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
             return 1;
         }
         
-        LuaState::pushVariant(arg1.get(arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.get(arg2));
         return 1;
     });
  
@@ -299,7 +299,7 @@ void LuaState::createRect2Metatable() {
     }); 
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__eq", {
-        LuaState::pushVariant(arg1.operator Rect2() == arg2.operator Rect2(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Rect2() == arg2.operator Rect2());
         return 1;
     });
  
@@ -312,13 +312,13 @@ void LuaState::createPlaneMetatable() {
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         if (arg1.has_method(arg2)) {
-            lua_pushlightuserdata(inner_state, lua_touserdata(inner_state,1));
-            LuaState::pushVariant(arg2, inner_state);
+            lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
             return 1;
         }
 
-        LuaState::pushVariant(arg1.get(arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.get(arg2));
         return 1;
     });
  
@@ -329,7 +329,7 @@ void LuaState::createPlaneMetatable() {
     }); 
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__eq", {
-        LuaState::pushVariant(arg1.operator Plane() == arg2.operator Plane(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Plane() == arg2.operator Plane());
         return 1;
     });
     
@@ -343,12 +343,12 @@ void LuaState::createColorMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         if (arg1.has_method(arg2)) {
             lua_pushlightuserdata(inner_state, lua_touserdata(inner_state,1));
-            LuaState::pushVariant(arg2, inner_state);
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
             return 1;
         }
         
-        LuaState::pushVariant(arg1.get(arg2), inner_state) ;
+        LuaState::pushVariant(inner_state, arg1.get(arg2)) ;
         return 1;
     });
  
@@ -359,23 +359,23 @@ void LuaState::createColorMetatable() {
     }); 
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__add", {
-        LuaState::pushVariant(arg1.operator Color() + arg2.operator Color(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Color() + arg2.operator Color());
     return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__sub", {
-        LuaState::pushVariant(arg1.operator Color() - arg2.operator Color(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Color() - arg2.operator Color());
     return 1;
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__mul", {
         switch(arg2.get_type()) {
             case Variant::Type::COLOR:
-                LuaState::pushVariant(arg1.operator Color() * arg2.operator Color(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Color() * arg2.operator Color());
                 return 1;
             case Variant::Type::INT:
             case Variant::Type::FLOAT:
-                LuaState::pushVariant(arg1.operator Color() * arg2.operator double(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Color() * arg2.operator double());
                 return 1;
             default:
                 return 0;
@@ -385,11 +385,11 @@ void LuaState::createColorMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__div", {
         switch(arg2.get_type()) {
             case Variant::Type::COLOR:
-                LuaState::pushVariant(arg1.operator Color() / arg2.operator Color(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Color() / arg2.operator Color());
                 return 1;
             case Variant::Type::INT:
             case Variant::Type::FLOAT:
-                LuaState::pushVariant(arg1.operator Color() / arg2.operator double(), inner_state);
+                LuaState::pushVariant(inner_state, arg1.operator Color() / arg2.operator double());
                 return 1;
             default:
                 return 0;
@@ -397,7 +397,7 @@ void LuaState::createColorMetatable() {
     });
  
     LUA_METAMETHOD_TEMPLATE(L, -1, "__eq", {
-        LuaState::pushVariant(arg1.operator Color() == arg2.operator Color(), inner_state);
+        LuaState::pushVariant(inner_state, arg1.operator Color() == arg2.operator Color());
         return 1;
     });
  
@@ -411,7 +411,7 @@ void LuaState::createObjectMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         // If object overrides
         if (arg1.has_method("__index")) {
-            LuaState::pushVariant(arg1.call("__index", arg2), inner_state);
+            LuaState::pushVariant(inner_state, arg1.call("__index", arg2));
             return 1;
         }
 
@@ -422,7 +422,7 @@ void LuaState::createObjectMetatable() {
         // If the functions is allowed and exists 
         if ((allowedFuncs.is_empty() || allowedFuncs.has(arg2)) && arg1.has_method(arg2)) {
             lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
-            LuaState::pushVariant(arg2, inner_state);
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
             return 1;
         }
@@ -434,7 +434,7 @@ void LuaState::createObjectMetatable() {
         // If the field is allowed
         if (allowedFields.is_empty() || allowedFields.has(arg2)) {
             Variant var = arg1.get(arg2);
-            LuaState::pushVariant(var, inner_state);
+            LuaState::pushVariant(inner_state, var);
             return 1;
         }
         
@@ -444,7 +444,7 @@ void LuaState::createObjectMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__newindex", {
         // If object overrides
         if (arg1.has_method("__newindex")) {
-            LuaState::pushVariant(arg1.call("__newindex", arg2, arg3), inner_state);
+            LuaState::pushVariant(inner_state, arg1.call("__newindex", arg2, arg3));
             return 1;
         }
 
@@ -479,10 +479,10 @@ void LuaState::createObjectMetatable() {
         
         Array args;
         for (int i = 1; i < argc; i++) {
-                args.push_back(LuaState::getVariant(i+1, inner_state, OBJ));
+                args.push_back(LuaState::getVariant(inner_state, i+1, OBJ));
         }
 
-        LuaState::pushVariant(arg1.call("__call", args), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__call", args));
         return 1;
     });
 
@@ -492,7 +492,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
 
-        LuaState::pushVariant(arg1.call("__tostring"), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__tostring"));
         return 1;        
     });
 
@@ -502,7 +502,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__metatable", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__metatable", arg2));
         return 1;        
     });
 
@@ -512,7 +512,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__len"), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__len"));
         return 1;        
     });
 
@@ -522,7 +522,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__unm"), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__unm"));
         return 1;        
     });
 
@@ -532,7 +532,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__add", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__add", arg2));
         return 1;        
     });
 
@@ -542,7 +542,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__sub", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__sub", arg2));
         return 1;        
     });
 
@@ -552,7 +552,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__mul", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__mul", arg2));
         return 1;        
     });
 
@@ -562,7 +562,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__div", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__div", arg2));
         return 1;        
     });
 
@@ -572,7 +572,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__idiv", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__idiv", arg2));
         return 1;        
     });
 
@@ -582,7 +582,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__mod", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__mod", arg2));
         return 1;        
     });
 
@@ -592,7 +592,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__pow", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__pow", arg2));
         return 1;        
     });
 
@@ -602,7 +602,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__concat", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__concat", arg2));
         return 1;        
     });
 
@@ -612,7 +612,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__band", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__band", arg2));
         return 1;        
     });
 
@@ -622,7 +622,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__bor", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__bor", arg2));
         return 1;        
     });
 
@@ -632,7 +632,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__bxor", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__bxor", arg2));
         return 1;        
     });
 
@@ -642,7 +642,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__bnot", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__bnot", arg2));
         return 1;        
     });
 
@@ -652,7 +652,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__shl", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__shl", arg2));
         return 1;        
     });
 
@@ -662,7 +662,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__shr", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__shr", arg2));
         return 1;        
     });
 
@@ -672,7 +672,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__eq", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__eq", arg2));
         return 1;        
     });
 
@@ -682,7 +682,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__lt", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__lt", arg2));
         return 1;        
     });
 
@@ -692,7 +692,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(arg1.call("__le", arg2), inner_state);
+        LuaState::pushVariant(inner_state, arg1.call("__le", arg2));
         return 1;        
     });
 
@@ -706,14 +706,14 @@ void LuaState::createRefCountedMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         Ref<RefCounted> refObj = Object::cast_to<RefCounted>((Object*) lua_touserdata(inner_state, 1));
         if (!refObj.is_valid()) {
-            LuaState::pushVariant(LuaError::newErr("during \"LuaState::createRefCountedMetatable __index metamethod\" Invalid RefCounted object.", LuaError::ERR_RUNTIME), inner_state);
+            LuaState::pushVariant(inner_state, LuaError::newErr("during \"LuaState::createRefCountedMetatable __index metamethod\" Invalid RefCounted object.", LuaError::ERR_RUNTIME));
             return 1;
         }
         
         // If the function exists 
         if (refObj->has_method(arg2)) {
             lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
-            LuaState::pushVariant(arg2, inner_state);
+            LuaState::pushVariant(inner_state, arg2);
             lua_pushcclosure(inner_state, luaLightUserdataFuncCall, 2);
             return 1;
         }
@@ -722,14 +722,14 @@ void LuaState::createRefCountedMetatable() {
         if(var.is_null())
             return 0;
 
-        LuaState::pushVariant(var, inner_state);
+        LuaState::pushVariant(inner_state, var);
         return 1;
     });
 
     LUA_METAMETHOD_TEMPLATE(L, -1, "__newindex", {
         Ref<RefCounted> refObj = Object::cast_to<RefCounted>((Object*) lua_touserdata(inner_state, 1));
         if (!refObj.is_valid()) {
-            LuaState::pushVariant(LuaError::newErr("during \"LuaState::createRefCountedMetatable __index metamethod\" Invalid RefCounted object.", LuaError::ERR_RUNTIME), inner_state);
+            LuaState::pushVariant(inner_state, LuaError::newErr("during \"LuaState::createRefCountedMetatable __index metamethod\" Invalid RefCounted object.", LuaError::ERR_RUNTIME));
             return 1;
         }
 

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -42,7 +42,7 @@ LuaError* LuaState::exposeObjectConstructor(String name, Object* obj) {
             Ref<RefCounted> temp = Object::cast_to<RefCounted>(var->operator Object*());
             lua_pushlightuserdata(inner_state, temp.ptr());
 
-             if (Ref<LuaAPI> lua = (Ref<LuaAPI>)OBJ; lua.is_valid())
+            if (Ref<LuaAPI> lua = (Ref<LuaAPI>)OBJ; lua.is_valid())
                 lua->addOwnedObject(temp.ptr());
 
             luaL_setmetatable(inner_state, "mt_RefCounted");

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -37,23 +37,17 @@ LuaError* LuaState::exposeObjectConstructor(String name, Object* obj) {
         // We cant store the variant directly in the userdata. It will causes crashes.
         Variant* var = memnew(Variant);
         *var = inner_obj->call("new");
+        if (Ref<LuaAPI> lua = (Ref<LuaAPI>)OBJ; lua.is_valid())
+            lua->addOwnedObject(var);
 
         if (var->is_ref_counted()) {
             Ref<RefCounted> temp = Object::cast_to<RefCounted>(var->operator Object*());
             lua_pushlightuserdata(inner_state, temp.ptr());
-
-            if (Ref<LuaAPI> lua = (Ref<LuaAPI>)OBJ; lua.is_valid())
-                lua->addOwnedObject(temp.ptr());
-
             luaL_setmetatable(inner_state, "mt_RefCounted");
             return 1;
         }
 
         void* userdata = (Variant*)lua_newuserdata(inner_state, sizeof(Variant));
-
-        if (Ref<LuaAPI> lua = (Ref<LuaAPI>)OBJ; lua.is_valid())
-            lua->addOwnedObject(var);
-
         memcpy(userdata, (void*)var, sizeof(Variant));
         luaL_setmetatable(inner_state, "mt_Object");
         return 1;


### PR DESCRIPTION
Changes:
- Changed the argument order for push_variant moving the name to be the first argument.
- Changed the argument order for expose_constructor moving the name to be the first argument.
- Added new metatable for mt_RefCounted.
- Added support to LuaState::pushVariant() for mt_RefCounted.
- Added support to LuaState::getVariant() for mt_RefCounted.
- Changed memory management. We now ignore Lua's garbage collector. Instead, all memory owned by the lua state is free'd at its death. This was a bi product of the change, and we may want to add support back in the future for Luas garbage collector.
- Readme and DOC info updated as well as some grammatical fixes.
