### PR TITLE
LuaTuple and LuaCallableExtra

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If you are looking to make your game using Lua or would like to support Modding 
 - [godot-lua-pluginscript](https://github.com/gilzoide/godot-lua-pluginscript) by [gilzoide](https://github.com/gilzoide)
 <br />
 
-We will supply a brief overview here. But for more info check out the [wiki](https://luaapi.weaselgames.info/2.0a).
+We will supply a brief overview here. But for more info check out the [wiki](https://luaapi.weaselgames.info/latest).
 
 Features
 --------------------------------
@@ -85,7 +85,7 @@ This build is for godot 4.0.0-beta. Will not be supporting older beta builds, we
 
 Examples
 ------------
-If you are looking for more in depth information please refer to our [wiki](https://luaapi.weaselgames.info/2.0a).
+If you are looking for more in depth information please refer to our [wiki](https://luaapi.weaselgames.info/latest).
 
 **Running Lua from a string:**
 ```gdscript

--- a/README.md
+++ b/README.md
@@ -215,12 +215,9 @@ var lua: LuaAPI
 
 class Player:
 	var pos = Vector2(0, 0)
-	# If lua_funcs is not defined or returns a empty array, all functions will be aval.
-	func lua_funcs():
-		return ["move_forward"]
-	# lua_fields behaves the same as lua_funcs but for fields.
+	# If lua_fields is not defined or returns a empty array, all functions and fields will be aval.
 	func lua_fields():
-		return ["pos"]
+		return ["pos", "move_forward"]
 	func move_forward():
 		pos.x+=1
 
@@ -247,7 +244,7 @@ var lua: LuaAPI
 class Player:
 	var pos = Vector2(1, 0)
 	# Most metamethods can be overriden. The function names are the same as the metamethods.
-	func __index(index):
+	func __index(ref: LuaAPI, index):
 		if index=="pos":
 			return pos
 		else:

--- a/doc_classes/LuaCallableExtra.xml
+++ b/doc_classes/LuaCallableExtra.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LuaCallableExtra" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A tuple.
+	</brief_description>
+	<description>
+		TODO
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="with_tuple" qualifiers="static">
+			<return type="LuaCallableExtra" />
+			<param index="0" name="function" type="Callable" />
+			<param index="1" name="argc" type="int" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="with_ref" qualifiers="static">
+			<return type="LuaCallableExtra" />
+			<param index="0" name="function" type="Callable" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="set_info">
+			<return type="void" />
+			<param index="0" name="function" type="Callable" />
+			<param index="1" name="argc" type="int" />
+			<param index="2" name="isTuple" type="bool" />
+			<param index="3" name="wantsRef" type="bool" />
+			<description>
+				TODO
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc_classes/LuaThread.xml
+++ b/doc_classes/LuaThread.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="LuaThread" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-	</brief_description>
 		A coroutine.
+	</brief_description>
 	<description>
 		Binds to a existing Lua object and creates a new lua thread with lua_newthread. This is not a typical thread but a coroutine. Instead of executing a file or string directly you load it into the state. Every time the resume method is caleld the lua code will execute untill yield is called from lua.
 	</description>

--- a/doc_classes/LuaTuple.xml
+++ b/doc_classes/LuaTuple.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LuaTuple" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		A tuple.
+	</brief_description>
+	<description>
+		TODO
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="from_array" qualifiers="static">
+			<return type="LuaTuple" />
+			<param index="0" name="elms" type="Array" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="push_back">
+			<return type="void" />
+			<param index="0" name="var" type="Variant" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="push_front">
+			<return type="void" />
+			<param index="0" name="var" type="Variant" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="set_value">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="var" type="Variant" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="is_empty">
+			<return type="bool" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="pop_back">
+			<return type="Variant" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="pop_front">
+			<return type="Variant" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="get_value">
+			<return type="Variant" />
+			<param index="0" name="index" type="int" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="to_array">
+			<return type="Array" />
+			<description>
+				TODO
+			</description>
+		</method>
+	</methods>
+</class>

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -4,6 +4,7 @@
 #include "src/classes/luaThread.h"
 #include "src/classes/luaCallable.h"
 #include "src/classes/luaTuple.h"
+#include "src/classes/luaCallableExtra.h"
 
 void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE)
@@ -13,6 +14,7 @@ void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<LuaThread>();
 	ClassDB::register_class<LuaError>();
 	ClassDB::register_class<LuaTuple>();
+	ClassDB::register_class<LuaCallableExtra>();
 }
 
 void uninitialize_luaAPI_module(ModuleInitializationLevel p_level) {

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -3,6 +3,7 @@
 #include "src/classes/luaError.h"
 #include "src/classes/luaThread.h"
 #include "src/classes/luaCallable.h"
+#include "src/classes/luaTuple.h"
 
 void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE)
@@ -11,6 +12,7 @@ void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<LuaAPI>();
 	ClassDB::register_class<LuaThread>();
 	ClassDB::register_class<LuaError>();
+	ClassDB::register_class<LuaTuple>();
 }
 
 void uninitialize_luaAPI_module(ModuleInitializationLevel p_level) {

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -26,8 +26,6 @@ void LuaAPI::_bind_methods() {
     ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
     ClassDB::bind_method(D_METHOD("call_function", "LuaFunctionName", "Args"), &LuaAPI::callFunction);
     ClassDB::bind_method(D_METHOD("function_exists", "LuaFunctionName"), &LuaAPI::luaFunctionExists);
-
-    ClassDB::bind_method(D_METHOD("push_function", "FunctionName", "Function", "noneMultiArg", "isTuple"), &LuaAPI::pushFunction);
 }
 
 // Calls LuaState::bindLibs()
@@ -54,10 +52,6 @@ void LuaAPI::removeOwnedObject(void* luaPtr) {
         return;
     memdelete(ownedObjects[luaPtr]);
     ownedObjects[luaPtr] = nullptr;
-}
-
-void LuaAPI::pushFunction(String functionName, Callable function, int argc, bool isTuple) {
-    state.pushFunction(functionName, function, argc, isTuple);
 }
 
 // Calls LuaState::luaFunctionExists()

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -26,6 +26,8 @@ void LuaAPI::_bind_methods() {
     ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
     ClassDB::bind_method(D_METHOD("call_function", "LuaFunctionName", "Args"), &LuaAPI::callFunction);
     ClassDB::bind_method(D_METHOD("function_exists", "LuaFunctionName"), &LuaAPI::luaFunctionExists);
+
+    ClassDB::bind_method(D_METHOD("push_function", "FunctionName", "Function", "noneMultiArg", "isTuple"), &LuaAPI::pushFunction);
 }
 
 // Calls LuaState::bindLibs()
@@ -52,6 +54,10 @@ void LuaAPI::removeOwnedObject(void* luaPtr) {
         return;
     memdelete(ownedObjects[luaPtr]);
     ownedObjects[luaPtr] = nullptr;
+}
+
+void LuaAPI::pushFunction(String functionName, Callable function, int argc, bool isTuple) {
+    state.pushFunction(functionName, function, argc, isTuple);
 }
 
 // Calls LuaState::luaFunctionExists()

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -26,6 +26,7 @@ class LuaAPI : public RefCounted {
         void addOwnedObject(void* luaPtr, Variant* obj);
         void removeOwnedObject(Variant* obj);
         void removeOwnedObject(void* luaPtr);
+        void pushFunction(String functionName, Callable function, int argc, bool tuple);
 
         bool luaFunctionExists(String functionName);
 

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <map>
 
-
 class LuaAPI : public RefCounted {
     GDCLASS(LuaAPI, RefCounted);
 
@@ -26,7 +25,6 @@ class LuaAPI : public RefCounted {
         void addOwnedObject(void* luaPtr, Variant* obj);
         void removeOwnedObject(Variant* obj);
         void removeOwnedObject(void* luaPtr);
-        void pushFunction(String functionName, Callable function, int argc, bool tuple);
 
         bool luaFunctionExists(String functionName);
 
@@ -41,9 +39,15 @@ class LuaAPI : public RefCounted {
         lua_State* newThread();
         lua_State* getState();
 
+        inline void addRef(Variant var) {
+            refs.append(var);
+        }
+
     private:
         LuaState state;
         lua_State* lState;
+        // Temp. Looking for better method
+        Array refs;
         std::map<void*, Variant*> ownedObjects;
         LuaError* execute(int handlerIndex);
 };

--- a/src/classes/luaCallableExtra.cpp
+++ b/src/classes/luaCallableExtra.cpp
@@ -1,0 +1,83 @@
+#include "luaCallableExtra.h"
+
+#include "luaState.h"
+#include "luaTuple.h"
+#include "core/variant/callable.h"
+
+void LuaCallableExtra::_bind_methods() {
+    ClassDB::bind_static_method("LuaCallableExtra", D_METHOD("with_tuple", "Callable", "argc"), &LuaCallableExtra::withTuple);
+    ClassDB::bind_static_method("LuaCallableExtra", D_METHOD("with_ref", "Callable"), &LuaCallableExtra::withRef);
+    ClassDB::bind_method(D_METHOD("set_info", "Callable", "argc", "isTuple", "wantsRef"), &LuaCallableExtra::setInfo);
+}
+
+void LuaCallableExtra::setInfo(Callable function, int argc, bool isTuple, bool wantsRef) {
+    this->function = function;
+    this->argc = argc;
+    this->isTuple = isTuple;
+    this->wantsRef = wantsRef;
+}
+
+// Used for the __call metamethod
+int LuaCallableExtra::call(lua_State *state) {
+    lua_pushstring(state, "__OBJECT");
+    lua_rawget(state, LUA_REGISTRYINDEX);
+    RefCounted* OBJ = (RefCounted*) lua_touserdata(state, -1);
+    lua_pop(state, 1);
+
+    int argc = lua_gettop(state)-1; // We subtract 1 becuase the LuaCallableExtra is counted
+    int noneMulty = argc;
+    // TODO: Check if func is null
+    LuaCallableExtra* func = (LuaCallableExtra*) LuaState::getVariant(state, 1, OBJ).operator Object*();
+    if (func->isTuple)
+        noneMulty=func->argc-1; // We subtract one becuase the tuple is countedA
+    
+    Vector<Variant> p_args;
+
+    if (func->wantsRef)
+        p_args.append(OBJ);
+
+    int index = 2; // we start at 2 becuase the LuaCallableExtra is arg 1
+    for (int i = 0; i < noneMulty; i++) {
+        p_args.append(LuaState::getVariant(state, index++, OBJ));
+    }
+
+    if (func->isTuple) {
+        Array tupleArgs;
+        for (int i = noneMulty; i < argc; i++) {
+            tupleArgs.push_back(LuaState::getVariant(state, index++, OBJ));
+        }
+        p_args.append(LuaTuple::fromArray(tupleArgs));
+    }
+
+    const Variant **args = (const Variant**)alloca(sizeof(const Variant**) * p_args.size());
+    for (int i = 0; i < p_args.size(); i++) {
+        args[i] = &p_args[i];
+    }
+
+    Variant returned;
+    Callable::CallError error;
+    func->function.callp(args, p_args.size(), returned, error);
+    if (error.error != error.CALL_OK) {
+        LuaError* err = LuaState::handleError(func->function.get_method(), error, args, argc);
+        lua_pushstring(state, err->getMessage().ascii().get_data());
+        lua_error(state);
+        return 0;
+    }
+
+    LuaState::pushVariant(state, returned);
+    if (LuaTuple* tuple = Object::cast_to<LuaTuple>(returned.operator Object*()); tuple != nullptr)
+        return tuple->size();
+    return 1;
+}
+
+LuaCallableExtra* LuaCallableExtra::withTuple(Callable func, int argc) {
+    LuaCallableExtra* toReturn = memnew(LuaCallableExtra);
+    toReturn->setInfo(func, argc, true, false);
+    return toReturn;
+}
+
+LuaCallableExtra* LuaCallableExtra::withRef(Callable func) {
+    LuaCallableExtra* toReturn = memnew(LuaCallableExtra);
+    toReturn->setInfo(func, 0, false, true);
+    return toReturn;
+}

--- a/src/classes/luaCallableExtra.h
+++ b/src/classes/luaCallableExtra.h
@@ -5,8 +5,6 @@
 
 #include <lua/lua.hpp>
 
-#include "LuaError.h"
-
 class LuaCallableExtra : public RefCounted {
     GDCLASS(LuaCallableExtra, RefCounted);
 

--- a/src/classes/luaCallableExtra.h
+++ b/src/classes/luaCallableExtra.h
@@ -1,0 +1,31 @@
+#ifndef LUACALLABLEEXTRA_H
+#define LUACALLABLEEXTRA_H
+#include "core/object/ref_counted.h"
+#include "core/core_bind.h"
+
+#include <lua/lua.hpp>
+
+#include "LuaError.h"
+
+class LuaCallableExtra : public RefCounted {
+    GDCLASS(LuaCallableExtra, RefCounted);
+
+    protected:
+        static void _bind_methods();
+
+    public:
+        static LuaCallableExtra* withTuple(Callable function, int argc);
+        static LuaCallableExtra* withRef(Callable function);
+
+        void setInfo(Callable function, int argc, bool isTuple, bool wantsRef);
+
+        static int call(lua_State *state);
+
+    private:
+        bool isTuple = false;
+        bool wantsRef = false;
+        int argc = 0;
+
+        Callable function;
+};
+#endif

--- a/src/classes/luaTuple.cpp
+++ b/src/classes/luaTuple.cpp
@@ -38,7 +38,7 @@ void LuaTuple::clear() {
 }
 
 bool LuaTuple::isEmpty() {
-    elements.is_empty();
+    return elements.is_empty();
 }
 
 int LuaTuple::size() {

--- a/src/classes/luaTuple.cpp
+++ b/src/classes/luaTuple.cpp
@@ -1,0 +1,62 @@
+#include "luaTuple.h"
+
+void LuaTuple::_bind_methods() {
+    ClassDB::bind_static_method("LuaTuple", D_METHOD("from_array", "Array"), &LuaTuple::fromArray);
+
+    ClassDB::bind_method(D_METHOD("push_back", "var"), &LuaTuple::pushBack);
+    ClassDB::bind_method(D_METHOD("push_front", "var"), &LuaTuple::pushFront);
+    ClassDB::bind_method(D_METHOD("set_value", "Index", "var"), &LuaTuple::set);
+    ClassDB::bind_method(D_METHOD("clear"), &LuaTuple::clear);
+    ClassDB::bind_method(D_METHOD("is_empty"), &LuaTuple::isEmpty);
+    ClassDB::bind_method(D_METHOD("size"), &LuaTuple::size);
+    ClassDB::bind_method(D_METHOD("pop_back"), &LuaTuple::popBack);
+    ClassDB::bind_method(D_METHOD("pop_front"), &LuaTuple::popFront);
+    ClassDB::bind_method(D_METHOD("get_value", "Index"), &LuaTuple::get);
+    ClassDB::bind_method(D_METHOD("to_array"), &LuaTuple::toArray);
+}
+
+LuaTuple* LuaTuple::fromArray(Array elms) {
+    LuaTuple* tuple = memnew(LuaTuple);
+    tuple->elements = elms;
+    return tuple;
+}
+
+void LuaTuple::pushBack(Variant var) {
+    elements.push_back(var);
+}
+
+void LuaTuple::pushFront(Variant var) {
+    elements.push_front(var);
+}
+
+void LuaTuple::set(int i, Variant var) {
+    elements.set(i, var);
+}
+
+void LuaTuple::clear() {
+    elements.clear();
+}
+
+bool LuaTuple::isEmpty() {
+    elements.is_empty();
+}
+
+int LuaTuple::size() {
+    return elements.size();
+}
+
+Variant LuaTuple::popBack() {
+    return elements.pop_back();
+}
+
+Variant LuaTuple::popFront() {
+    return elements.pop_front();
+}
+
+Variant LuaTuple::get(int i) {
+    return elements.get(i);
+}
+
+Array LuaTuple::toArray() {
+    return elements;
+}

--- a/src/classes/luaTuple.h
+++ b/src/classes/luaTuple.h
@@ -1,0 +1,32 @@
+#ifndef LUATUPLE_H
+#define LUATUPLE_H
+#include "core/object/ref_counted.h"
+#include "core/core_bind.h"
+
+class LuaTuple : public RefCounted {
+    GDCLASS(LuaTuple, RefCounted);
+
+    protected:
+        static void _bind_methods();
+    
+    public:
+        static LuaTuple* fromArray(Array elms);
+
+        void pushBack(Variant var);
+        void pushFront(Variant var);
+        void set(int i, Variant var);
+        void clear();
+
+        bool isEmpty();
+
+        int size();
+
+        Variant popBack();
+        Variant popFront();
+        Variant get(int i);
+
+        Array toArray();
+    private:
+        Array elements;
+};
+#endif

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -500,18 +500,19 @@ int LuaState::luaCallableCall(lua_State* state) {
     Callable callable = (Callable) LuaState::getVariant(state, 1, OBJ);
    
     const Variant **args = (const Variant **)alloca(sizeof(const Variant **) * argc);
-    Vector<Variant> p_args;
     int index = 2; // we start at 2, 1 is the callable
     for (int i = 0; i < argc; i++) {
-        p_args.set(i, LuaState::getVariant(state, index++, OBJ));
-        args[i] = &p_args[i];
-        if (args[i]->get_type() == Variant::Type::OBJECT) {
-            if (LuaError* err = Object::cast_to<LuaError>(args[i]->operator Object*()); err != nullptr) {
+        Variant* temp = memnew(Variant);
+        *temp = LuaState::getVariant(state, index++, OBJ);
+        if ((*temp).get_type() != Variant::Type::OBJECT) {
+            if (LuaError* err = Object::cast_to<LuaError>(temp->operator Object*()); err != nullptr) {
                 lua_pushstring(state, err->getMessage().ascii().get_data());
                 lua_error(state);
                 return 0;
             }
         }
+
+        args[i] = temp;
     }
 
     Variant returned;

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -2,6 +2,7 @@
 #define LUASTATE_H
 
 #include "core/object/ref_counted.h"
+#include "core/variant/callable.h"
 
 #include <lua/lua.hpp>
 #include <classes/luaError.h>
@@ -10,6 +11,7 @@ class LuaState {
     public:
         void setState(lua_State* state, RefCounted* obj, bool bindAPI);
         void bindLibraries(Array libs);
+        void pushFunction(String functionName, Callable function, int argc, bool tuple) const;
 
         bool luaFunctionExists(String functionName);
 
@@ -35,7 +37,6 @@ class LuaState {
         static int luaPrint(lua_State* state);
         static int luaExposedFuncCall(lua_State* state);
         static int luaUserdataFuncCall(lua_State* state);
-        static int luaLightUserdataFuncCall(lua_State* state);
         static int luaCallableCall(lua_State* state);
     private:
         lua_State *L = nullptr;
@@ -48,7 +49,6 @@ class LuaState {
         void createRect2Metatable();
         void createPlaneMetatable();
         void createObjectMetatable();
-        void createRefCountedMetatable();
         void createCallableMetatable();
 };
 

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -50,6 +50,7 @@ class LuaState {
         void createPlaneMetatable();
         void createObjectMetatable();
         void createCallableMetatable();
+        void createCallableExtraMetatable();
 };
 
 #endif

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -401,19 +401,7 @@ void LuaState::createObjectMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         // If object overrides
         if (arg1.has_method("__index")) {
-            LuaState::pushVariant(inner_state, arg1.call("__index", arg1, arg2));
-            return 1;
-        }
-
-        Array allowedFuncs = Array();
-        if (arg1.has_method("lua_funcs")) {
-            allowedFuncs = arg1.call("lua_funcs");
-        }
-        // If the functions is allowed and exists 
-        if ((allowedFuncs.is_empty() || allowedFuncs.has(arg2)) && arg1.has_method(arg2)) {
-            lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
-            LuaState::pushVariant(inner_state, arg2);
-            lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
+            LuaState::pushVariant(inner_state, arg1.call("__index", Ref<LuaAPI>(OBJ), arg2));
             return 1;
         }
 
@@ -421,6 +409,15 @@ void LuaState::createObjectMetatable() {
         if (arg1.has_method("lua_fields")) {
             allowedFields = arg1.call("lua_fields");
         }
+
+        // If the functions is allowed and exists 
+        if ((allowedFields.is_empty() || allowedFields.has(arg2)) && arg1.has_method(arg2)) {
+            lua_pushlightuserdata(inner_state, lua_touserdata(inner_state, 1));
+            LuaState::pushVariant(inner_state, arg2);
+            lua_pushcclosure(inner_state, luaUserdataFuncCall, 2);
+            return 1;
+        }
+
         // If the field is allowed
         if (allowedFields.is_empty() || allowedFields.has(arg2)) {
             Variant var = arg1.get(arg2);
@@ -434,7 +431,7 @@ void LuaState::createObjectMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__newindex", {
         // If object overrides
         if (arg1.has_method("__newindex")) {
-            LuaState::pushVariant(inner_state, arg1.call("__newindex", arg1, arg2, arg3));
+            LuaState::pushVariant(inner_state, arg1.call("__newindex", Ref<LuaAPI>(OBJ), arg2, arg3));
             return 1;
         }
 
@@ -470,7 +467,7 @@ void LuaState::createObjectMetatable() {
                 args.push_back(LuaState::getVariant(inner_state, i+1, OBJ));
         }
 
-        LuaState::pushVariant(inner_state, arg1.call("__call", arg1, LuaTuple::fromArray(args)));
+        LuaState::pushVariant(inner_state, arg1.call("__call", Ref<LuaAPI>(OBJ), LuaTuple::fromArray(args)));
         return 1;
     });
 
@@ -480,7 +477,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
 
-        LuaState::pushVariant(inner_state, arg1.call("__tostring", arg1));
+        LuaState::pushVariant(inner_state, arg1.call("__tostring", Ref<LuaAPI>(OBJ)));
         return 1;        
     });
 
@@ -490,7 +487,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__metatable", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__metatable", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -500,7 +497,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__len", arg1));
+        LuaState::pushVariant(inner_state, arg1.call("__len", Ref<LuaAPI>(OBJ)));
         return 1;        
     });
 
@@ -510,7 +507,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__unm", arg1));
+        LuaState::pushVariant(inner_state, arg1.call("__unm", Ref<LuaAPI>(OBJ)));
         return 1;        
     });
 
@@ -520,7 +517,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__add", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__add", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -530,7 +527,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__sub", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__sub", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -540,7 +537,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__mul", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__mul", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -550,7 +547,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__div", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__div", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -560,7 +557,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__idiv", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__idiv", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -570,7 +567,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__mod", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__mod", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -580,7 +577,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__pow", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__pow", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -590,7 +587,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__concat", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__concat", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -600,7 +597,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__band", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__band", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -610,7 +607,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__bor", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__bor", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -620,7 +617,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__bxor", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__bxor", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -630,7 +627,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__bnot", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__bnot", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -640,7 +637,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__shl", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__shl", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -650,7 +647,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__shr", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__shr", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -660,7 +657,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__eq", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__eq", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -670,7 +667,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__lt", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__lt", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 
@@ -680,7 +677,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__le", arg1, arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__le", Ref<LuaAPI>(OBJ), arg2));
         return 1;        
     });
 

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -1,6 +1,7 @@
 #include "luaState.h"
 
 #include <classes/luaAPI.h>
+#include <classes/luaCallableExtra.h>
 
 // These 2 macros helps us in constructing general metamethods.
 // We can use "lua" as a "Lua" pointer and arg1, arg2, ..., arg5 as Variants objects
@@ -9,7 +10,7 @@
  [](lua_State* inner_state) -> int {                                          \
      lua_pushstring(inner_state,"__OBJECT");                                  \
      lua_rawget(inner_state,LUA_REGISTRYINDEX);                               \
-     RefCounted* OBJ = (RefCounted*) lua_touserdata(inner_state, -1); \
+     RefCounted* OBJ = (RefCounted*) lua_touserdata(inner_state, -1);         \
      lua_pop(inner_state, 1);                                                 \
      Variant arg1 = LuaState::getVariant(inner_state, 1, OBJ);                \
      Variant arg2 = LuaState::getVariant(inner_state, 2, OBJ);                \
@@ -691,6 +692,17 @@ void LuaState::createCallableMetatable() {
 
     lua_pushstring(L, "__call"); 
     lua_pushcfunction(L, luaCallableCall);
+    lua_settable(L, -3);
+    
+    lua_pop(L, 1);
+}
+
+// Create metatable for any Callable and saves it at LUA_REGISTRYINDEX with name "mt_Callable"
+void LuaState::createCallableExtraMetatable() {
+    luaL_newmetatable(L, "mt_CallableExtra");
+
+    lua_pushstring(L, "__call"); 
+    lua_pushcfunction(L, LuaCallableExtra::call);
     lua_settable(L, -3);
     
     lua_pop(L, 1);

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -1,6 +1,7 @@
 #include "luaState.h"
 
 #include <classes/luaAPI.h>
+#include <classes/luaTuple.h>
 #include <classes/luaCallableExtra.h>
 
 // These 2 macros helps us in constructing general metamethods.
@@ -400,7 +401,7 @@ void LuaState::createObjectMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
         // If object overrides
         if (arg1.has_method("__index")) {
-            LuaState::pushVariant(inner_state, arg1.call("__index", arg2));
+            LuaState::pushVariant(inner_state, arg1.call("__index", arg1, arg2));
             return 1;
         }
 
@@ -433,7 +434,7 @@ void LuaState::createObjectMetatable() {
     LUA_METAMETHOD_TEMPLATE(L, -1, "__newindex", {
         // If object overrides
         if (arg1.has_method("__newindex")) {
-            LuaState::pushVariant(inner_state, arg1.call("__newindex", arg2, arg3));
+            LuaState::pushVariant(inner_state, arg1.call("__newindex", arg1, arg2, arg3));
             return 1;
         }
 
@@ -469,7 +470,7 @@ void LuaState::createObjectMetatable() {
                 args.push_back(LuaState::getVariant(inner_state, i+1, OBJ));
         }
 
-        LuaState::pushVariant(inner_state, arg1.call("__call", args));
+        LuaState::pushVariant(inner_state, arg1.call("__call", arg1, LuaTuple::fromArray(args)));
         return 1;
     });
 
@@ -479,7 +480,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
 
-        LuaState::pushVariant(inner_state, arg1.call("__tostring"));
+        LuaState::pushVariant(inner_state, arg1.call("__tostring", arg1));
         return 1;        
     });
 
@@ -489,7 +490,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__metatable", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__metatable", arg1, arg2));
         return 1;        
     });
 
@@ -499,7 +500,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__len"));
+        LuaState::pushVariant(inner_state, arg1.call("__len", arg1));
         return 1;        
     });
 
@@ -509,7 +510,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__unm"));
+        LuaState::pushVariant(inner_state, arg1.call("__unm", arg1));
         return 1;        
     });
 
@@ -519,7 +520,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__add", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__add", arg1, arg2));
         return 1;        
     });
 
@@ -529,7 +530,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__sub", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__sub", arg1, arg2));
         return 1;        
     });
 
@@ -539,7 +540,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__mul", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__mul", arg1, arg2));
         return 1;        
     });
 
@@ -549,7 +550,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__div", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__div", arg1, arg2));
         return 1;        
     });
 
@@ -559,7 +560,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__idiv", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__idiv", arg1, arg2));
         return 1;        
     });
 
@@ -569,7 +570,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__mod", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__mod", arg1, arg2));
         return 1;        
     });
 
@@ -579,7 +580,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__pow", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__pow", arg1, arg2));
         return 1;        
     });
 
@@ -589,7 +590,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__concat", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__concat", arg1, arg2));
         return 1;        
     });
 
@@ -599,7 +600,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__band", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__band", arg1, arg2));
         return 1;        
     });
 
@@ -609,7 +610,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__bor", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__bor", arg1, arg2));
         return 1;        
     });
 
@@ -619,7 +620,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__bxor", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__bxor", arg1, arg2));
         return 1;        
     });
 
@@ -629,7 +630,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__bnot", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__bnot", arg1, arg2));
         return 1;        
     });
 
@@ -639,7 +640,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__shl", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__shl", arg1, arg2));
         return 1;        
     });
 
@@ -649,7 +650,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__shr", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__shr", arg1, arg2));
         return 1;        
     });
 
@@ -659,7 +660,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__eq", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__eq", arg1, arg2));
         return 1;        
     });
 
@@ -669,7 +670,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__lt", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__lt", arg1, arg2));
         return 1;        
     });
 
@@ -679,7 +680,7 @@ void LuaState::createObjectMetatable() {
             return 0;
         }
         
-        LuaState::pushVariant(inner_state, arg1.call("__le", arg2));
+        LuaState::pushVariant(inner_state, arg1.call("__le", arg1, arg2));
         return 1;        
     });
 

--- a/testing/run_tests.gd
+++ b/testing/run_tests.gd
@@ -1,7 +1,7 @@
-#!/usr/bin/env -S godot -s
+#!/usr/bin/env -S godot --headless -s
 
 # This is a standalone script meant to be run via CI
-class_name RunTests
+#class_name RunTests
 extends SceneTree
 
 var time_elapsed = 0
@@ -81,6 +81,7 @@ func finish():
 		test.free()
 	
 	doneTests.clear()
+	logPrint("%d/" % failures + "%d tests failed." % testCount)
 	quit(failures)
 
 

--- a/testing/tests/LuaAPI.expose_function.gd
+++ b/testing/tests/LuaAPI.expose_function.gd
@@ -1,0 +1,100 @@
+extends UnitTest
+var lua: LuaAPI
+	
+func testFuncTuple(arg1: String, tuple: LuaTuple):
+	if not arg1 == "Hello World!":
+		errors.append(LuaError.new_error("arg1 is not 'Hello World!' but is '%s'" % arg1))
+		return fail()
+		
+	if not tuple.size()==2:
+		errors.append(LuaError.new_error("tuple.size() is not 2 but is %d" % tuple.size()))
+		return fail()
+		
+	var val1 = tuple.pop_front()
+	if val1:
+		errors.append(LuaError.new_error("val1 is true"))
+		return fail()
+		
+	var val2 = tuple.pop_front()
+	if not val2 == 5:
+		errors.append(LuaError.new_error("val2 is not 5 but is %d" % val2))
+		return fail()
+	return true
+
+func testFuncRef(ref: LuaAPI, arg1: String):
+	if not arg1 == "Hello World!":
+		errors.append(LuaError.new_error("arg1 is not 'Hello World!' but is '%s'" % arg1))
+		return fail()
+		
+	if not ref.get_meta("isValid"):
+		errors.append(LuaError.new_error("ref meta isValid is false or has no value"))
+		return fail()
+	return true
+
+func testNormal(a, b): return a+b
+
+func _init():
+	# Since we are using poly here, we need to make sure to call super for _methods
+	super._init()
+	# id will determine the load order
+	id = 9940
+	
+	lua = LuaAPI.new()
+	lua.set_meta("isValid", true)
+	var err = lua.push_variant("test1", LuaCallableExtra.with_tuple(testFuncTuple, 2))
+	if err is LuaError:
+		errors.append(err)
+		fail()
+	
+	err = lua.push_variant("test2", LuaCallableExtra.with_ref(testFuncRef))
+	if err is LuaError:
+		errors.append(err)
+		fail()
+	
+	err = lua.push_variant("test3", testNormal)
+	if err is LuaError:
+		errors.append(err)
+		fail()
+		
+	# testName and testDescription are for any needed context about the test.
+	testName = "LuaAPI.expose_function"
+	testDescription = "
+Tests exposeing functions to GDScript. Including
+- wants ref
+- is tuple
+- normal
+"
+
+func fail():
+	status = false
+	done = true
+
+func _process(delta):
+	# Since we are using poly here, we need to make sure to call super for _methods
+	super._process(delta)
+	
+	var err = lua.do_string("
+	result1 = test1('Hello World!', false, 5)
+	result2 = test2('Hello World!')
+	result3 = test3(5, 5)
+	")
+	if err is LuaError:
+		errors.append(err)
+		return fail()
+	
+	var result1 = lua.pull_variant("result1")
+	if not result1:
+		errors.append("result1 is false")
+		fail()
+	
+	var result2 = lua.pull_variant("result2")
+	if not result2:
+		errors.append("result2 is false")
+		fail()
+	
+	var result3 = lua.pull_variant("result3")
+	if not result3 == 10:
+		errors.append("result3 is not 10 but is %d" % result3)
+		fail()
+		
+	done = true

--- a/testing/tests/general.object_metamethods.gd
+++ b/testing/tests/general.object_metamethods.gd
@@ -21,10 +21,9 @@ func _init():
 	lua.push_variant("testObj", testObj)
 	
 	# testName and testDescription are for any needed context about the test.
-	testName = "General.gdfunction_call"
+	testName = "General.object_metamethod"
 	testDescription = "
-Runs the fibonacci sequence of 15 and verifies the result.
-Number is passed via push_variant.
+Tests objects overiding lua metamethods.
 "
 
 func fail():

--- a/testing/tests/general.object_metamethods.gd
+++ b/testing/tests/general.object_metamethods.gd
@@ -1,8 +1,13 @@
 extends UnitTest
 var lua: LuaAPI
-
-func lua_get_frames()->int:
-	return frames
+var testObj: TestObject
+class TestObject:
+	func __index(ref: LuaAPI, index: String):
+		if index=="test1":
+			return ref.get_meta("isValid")
+		elif index=="test2":
+			return 5
+		
 
 func _init():
 	# Since we are using poly here, we need to make sure to call super for _methods
@@ -11,11 +16,9 @@ func _init():
 	id = 9850
 
 	lua = LuaAPI.new()
-	
-	var err = lua.push_variant("getFrames", lua_get_frames)
-	if err is LuaError:
-		errors.append(err)
-		fail()
+	lua.set_meta("isValid", true)
+	testObj = TestObject.new()
+	lua.push_variant("testObj", testObj)
 	
 	# testName and testDescription are for any needed context about the test.
 	testName = "General.gdfunction_call"
@@ -32,23 +35,30 @@ func _process(delta):
 	# Since we are using poly here, we need to make sure to call super for _methods
 	super._process(delta)
 	
-	var err = lua.do_string("result = getFrames()")
+	var err = lua.do_string("
+	result1 = testObj.test1
+	result2 = testObj.test2
+	")
 	if err is LuaError:
 		errors.append(err)
 		return fail()
 		
-	var result = lua.pull_variant("result")
-	if result is LuaError:
+	var result1 = lua.pull_variant("result1")
+	if result1 is LuaError:
 		errors.append(err)
 		return fail()
 		
-	if not result is float:
-		errors.append(LuaError.new_error("Result is not float but is '%d'" % typeof(result), LuaError.ERR_TYPE))
+	if not result1:
+		errors.append(LuaError.new_error("ref meta isValid is false or has no value"))
 		return fail()
 		
-	if not result == frames:
-		errors.append(LuaError.new_error("Result is not 610 but is '%d'" % result))
+	var result2 = lua.pull_variant("result2")
+	if result2 is LuaError:
+		errors.append(err)
 		return fail()
 		
-	if frames == 200:
-		done = true
+	if not result2 == 5:
+		errors.append(LuaError.new_error("result2 is not 5 but is %d" % result2))
+		return fail()
+		
+	done = true


### PR DESCRIPTION
Changes:
- Fixed bug with arguments passed to mt_Callable
- Added new LuaTuple type. The type is a container for array. resolves #64 
- Added new LuaCallableExtra type. A wrapper class for Callable to support extra functionality. Such as passing ref or taking a tuple argument. resolves #63
- Removed the lua_funcs method check from objects. lua_fields now serves both roles. 
- Added some more tests