### PR TITLE
Bug fix with lua garbage collector

### DIFF
--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -38,22 +38,6 @@ void LuaAPI::addOwnedObject(void* luaPtr, Variant* obj) {
     ownedObjects[luaPtr] = obj;
 }
 
-// Adds the pointer to a object now owned by lua for cleanup later
-void LuaAPI::removeOwnedObject(Variant* obj) {
-    if (ownedObjects.empty() || ownedObjects.count((void*)obj)==0)
-        return;
-    memdelete(ownedObjects[(void*)obj]);
-    ownedObjects[(void*)obj] = nullptr;
-}
-
-// Adds the pointer to a object now owned by lua for cleanup later
-void LuaAPI::removeOwnedObject(void* luaPtr) {
-    if (ownedObjects.empty() || ownedObjects.count(luaPtr)==0)
-        return;
-    memdelete(ownedObjects[luaPtr]);
-    ownedObjects[luaPtr] = nullptr;
-}
-
 // Calls LuaState::luaFunctionExists()
 bool LuaAPI::luaFunctionExists(String functionName) {
     return state.luaFunctionExists(functionName);

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -23,8 +23,6 @@ class LuaAPI : public RefCounted {
 
         void bindLibraries(Array libs);
         void addOwnedObject(void* luaPtr, Variant* obj);
-        void removeOwnedObject(Variant* obj);
-        void removeOwnedObject(void* luaPtr);
 
         bool luaFunctionExists(String functionName);
 

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -447,15 +447,6 @@ void LuaState::createObjectMetatable() {
         return 0;
     }); 
 
-    // Makeing sure to clean up the pointer with lua GC
-    LUA_METAMETHOD_TEMPLATE(L, -1, "__gc", {
-        void* luaPtr = lua_touserdata(inner_state, 1);
-        Ref<LuaAPI> lua = (Ref<LuaAPI>)OBJ;
-        if (lua.is_valid())
-            lua->removeOwnedObject(luaPtr);
-        return 0;
-    });
-
     LUA_METAMETHOD_TEMPLATE(L, -1, "__call", {
         if (!arg1.has_method("__call")) {
                 return 0;


### PR DESCRIPTION
This PR fixes #75, the issue was caused when lua invoked mt_Object's __gc meta method for garbage collection. Sometimes it would be called during an none optimal time. Instead this PR makes all object live the life of the LuaAPI object.