### PR TITLE
Remove confusing argc behavior

### DIFF
--- a/doc_classes/LuaCallableExtra.xml
+++ b/doc_classes/LuaCallableExtra.xml
@@ -8,6 +8,17 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<members>
+		<member name="tuple" type="bool" setter="set_tuple" getter="get_tuple" default="false">
+			TODO
+		</member>
+		<member name="wants_ref" type="bool" setter="set_wants_ref" getter="get_wants_ref" default="false">
+			TODO
+		</member>
+		<member name="argc" type="int" setter="set_argc" getter="get_argc" default="0">
+			TODO
+		</member>
+	</members>
 	<methods>
 		<method name="with_tuple" qualifiers="static">
 			<return type="LuaCallableExtra" />
@@ -20,6 +31,14 @@
 		<method name="with_ref" qualifiers="static">
 			<return type="LuaCallableExtra" />
 			<param index="0" name="function" type="Callable" />
+			<description>
+				TODO
+			</description>
+		</method>
+		<method name="with_ref_and_tuple" qualifiers="static">
+			<return type="LuaCallableExtra" />
+			<param index="0" name="function" type="Callable" />
+			<param index="1" name="argc" type="int" />
 			<description>
 				TODO
 			</description>

--- a/src/classes/luaCallableExtra.h
+++ b/src/classes/luaCallableExtra.h
@@ -14,8 +14,18 @@ class LuaCallableExtra : public RefCounted {
     public:
         static LuaCallableExtra* withTuple(Callable function, int argc);
         static LuaCallableExtra* withRef(Callable function);
+        static LuaCallableExtra* withRefAndTuple(Callable function, int argc);
 
         void setInfo(Callable function, int argc, bool isTuple, bool wantsRef);
+
+        void setTuple(bool isTuple);
+        bool getTuple();
+
+        void setWantsRef(bool wantsRef);
+        bool getWantsRef();
+
+        void setArgc(int argc);
+        int getArgc();
 
         static int call(lua_State *state);
 

--- a/testing/tests/LuaAPI.expose_function.gd
+++ b/testing/tests/LuaAPI.expose_function.gd
@@ -41,7 +41,7 @@ func _init():
 	
 	lua = LuaAPI.new()
 	lua.set_meta("isValid", true)
-	var err = lua.push_variant("test1", LuaCallableExtra.with_tuple(testFuncTuple, 2))
+	var err = lua.push_variant("test1", LuaCallableExtra.with_tuple(testFuncTuple, 1))
 	if err is LuaError:
 		errors.append(err)
 		fail()


### PR DESCRIPTION
Previously the argc property of LuaCallableExtra expected the LuaTuple to be counted but not the LuaAPI reference. Instead now neither are counted and arc is to be used for additional arguments only. Hopefully this helps remove some confusion. 

Changes:
- LuaCallableExtra no longer expects LuaTuple to be counted.
- LuaCallableExtra now checks if the Callable instance is invalid before attempting to invoke it.
- LuaCallableExtra now has tuple, wants_ref, and argc as properties.
- LuaCallableExtra  has a new static method to go with with_tuple and with_ref, with_ref_and_tuple.
- Tests modified according to changes.