### PR TITLE
Add LuaJIT support

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -66,7 +66,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=linuxbsd tools=yes target=editor
+          scons platform=linuxbsd tools=yes target=editor extra_suffix=luaAPI
+          scons platform=linuxbsd tools=yes target=editor luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*
@@ -117,7 +118,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=linuxbsd tools=no target=template_release
+          scons platform=linuxbsd tools=no target=template_release extra_suffix=luaAPI
+          scons platform=linuxbsd tools=no target=template_release luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*
@@ -168,7 +170,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=linuxbsd tools=no target=template_debug
+          scons platform=linuxbsd tools=no target=template_debug extra_suffix=luaAPI
+          scons platform=linuxbsd tools=no target=template_debug luaapi_luajit=yes extra_suffix=luaAPI
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -66,7 +66,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=macos tools=yes target=editor
+          scons platform=macos tools=yes target=editor extra_suffix=luaAPI 
+          scons platform=macos tools=yes target=editor luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*
@@ -118,7 +119,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=macos target=template_release tools=no
+          scons platform=macos target=template_release tools=no extra_suffix=luaAPI
+          scons platform=macos target=template_release tools=no luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*
@@ -170,7 +172,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=macos target=template_debug tools=no
+          scons platform=macos target=template_debug tools=no extra_suffix=luaAPI
+          scons platform=macos target=template_debug tools=no luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*

--- a/.github/workflows/unit_testing.yml
+++ b/.github/workflows/unit_testing.yml
@@ -65,7 +65,8 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=linuxbsd tools=yes target=editor
+          scons platform=linuxbsd tools=yes target=editor extra_suffix=luaAPI
+          scons platform=linuxbsd tools=yes target=editor luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           strip scripts/godot/bin/godot.*
@@ -77,4 +78,4 @@ jobs:
         if: ${{ always() }}
         with:
           name: ${{github.job}}
-          path: testing/log.txt
+          path: testing/*.txt

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -63,8 +63,8 @@ jobs:
         env:
           SCONS_CACHE: /.scons_cache/
         run: |
-          scons platform=windows tools=yes target=editor
-
+          scons platform=windows tools=yes target=editor extra_suffix=luaAPI
+          scons platform=windows tools=yes target=editor luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           Remove-Item scripts/godot/bin/* -Include *.exp,*.lib,*.pdb -Force
@@ -111,7 +111,8 @@ jobs:
         env:
           SCONS_CACHE: /.scons_cache/
         run: |
-          scons platform=windows target=template_release tools=no
+          scons platform=windows target=template_release tools=no extra_suffix=luaAPI
+          scons platform=windows target=template_release tools=no luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           Remove-Item scripts/godot/bin/* -Include *.exp,*.lib,*.pdb -Force
@@ -158,7 +159,8 @@ jobs:
         env:
           SCONS_CACHE: /.scons_cache/
         run: |
-          scons platform=windows target=template_debug tools=no
+          scons platform=windows target=template_debug tools=no extra_suffix=luaAPI
+          scons platform=windows target=template_debug tools=no luaapi_luajit=yes extra_suffix=luaAPI.LuaJIT
       - name: Prepare artifact
         run: |
           Remove-Item scripts/godot/bin/* -Include *.exp,*.lib,*.pdb -Force

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,3 +2,7 @@
 	path = external/lua
 	url = https://github.com/lua/lua
 	branch = 5d708c3
+[submodule "external/luaJIT"]
+	path = external/luaJIT
+	url = https://github.com/luaJIT/luaJIT
+	branch = v2.0

--- a/SCsub
+++ b/SCsub
@@ -6,15 +6,17 @@ Import('env_modules')
 env_lua = env_modules.Clone()
 
 if not env.msvc:
-    CXXFLAGS='-std=c++17'
+    CXXFLAGS=['-std=c++17']
 else:
-    CXXFLAGS='/std:c++17'
+    CXXFLAGS=['/std:c++17']
 
-env_lua['CXXFLAGS'] = [CXXFLAGS]
+env_lua.Append(CXXFLAGS=CXXFLAGS)
 
 Export('env_lua')
-
 SConscript('external/SCsub')
+
+if env["luaapi_luajit"]:
+    env_lua.Append(CPPDEFINES=['LAPI_LUAJIT'])
 
 env_lua.Append(CPPPATH=[Dir('src').abspath])
 env_lua.Append(CPPPATH=[Dir('external').abspath])

--- a/config.py
+++ b/config.py
@@ -2,7 +2,22 @@ def can_build(env, platform):
     return True
 
 def configure(env):
-    pass
+    from SCons.Script import BoolVariable, EnumVariable, Variables, Help
+
+    env_vars = Variables()
+
+    env_vars.Add(BoolVariable("luaapi_luajit", 
+    "Build the LuaAPI module with luaJIT v2.0 instead of Lua v5.4", False))
+
+    env_vars.Add(BoolVariable("luaapi_luajit_build", 
+    "When LuaAPI is using luaJIT, be defualt it will attempt to build it automatically. if you prefer you can build it manually and disable auto building with this flag. Make sure to build staticly and that the libs are in external/luaJIT/src", 
+    True))
+
+    env_vars.Add(EnumVariable("luaapi_host_cc", 
+    "LuaJIT builds some tools to assit with the rest of the build. You can set the host CC to be used here in the case of cross compilation.", "gcc", ("gcc", "clang")))
+    
+    env_vars.Update(env)
+    Help(env_vars.GenerateHelpText(env))
 
 def get_doc_classes():
     return [

--- a/external/SCsub
+++ b/external/SCsub
@@ -8,19 +8,22 @@ import SCons.Script
 
 def run(cmd):
     res = os.system(cmd)
-    if (os.WIFEXITED(res)):
+    code = 0
+    if (os.name == 'nt'):
+        code = res
+    else:
         code = os.WEXITSTATUS(res)
-        if code != 0:
-            print("Error: return code: " + str(code))
-            if SCons.Script.keep_going_on_error == 0:
-                sys.exit(code)
+    if code != 0:
+        print("Error: return code: " + str(code))
+        if SCons.Script.keep_going_on_error == 0:
+            sys.exit(code)
 
 def build_luajit():
     if not env_lua.msvc:
         os.chdir("luaJIT")
         run("make clean")
 
-        if env['PLATFORM'] == 'posix' and env["platform"] == 'windows':
+        if env['PLATFORM'] == 'posix' and env['platform'] == 'windows':
             run('make HOST_CC="%s" CROSS="%s" TARGET_SYS=Windows BUILDMODE="static"' % (env['luaapi_host_cc'], env['CC'].replace("gcc", "")))
         else:
             run('make CC="%s" BUILDMODE="static"' % env['CC'])
@@ -33,13 +36,18 @@ env_lua = env_lua.Clone()
 if env["luaapi_luajit"]:
     if env["luaapi_luajit_build"]:
         build_luajit()
-    env.Append(LIBPATH=[Dir("luaJIT/src").abspath])
-    env.Append(LIBS=['libluajit'])
+    if env_lua.msvc:
+        # hack for msvc builds. See https://github.com/godotengine/godot/issues/23687
+        env.Append(LIBS=[File('luaJIT/src/luajit.lib')])
+        env.Append(LIBS=[File('luaJIT/src/lua51.lib')])
+    else:
+        env.Append(LIBPATH=[Dir("luaJIT/src").abspath])
+        env.Append(LIBS=['libluajit'])
     
 else:
     env_lua.Append(CPPDEFINES='MAKE_LIB')
 
-    if env['PLATFORM'] == 'posix' and env["platform"] == 'linuxbsd':
+    if env['PLATFORM'] == 'posix' and env['platform'] == 'linuxbsd':
         env_lua.Append(CPPDEFINES='LUA_USE_POSIX')
 
     if not env_lua.msvc:

--- a/external/SCsub
+++ b/external/SCsub
@@ -2,15 +2,49 @@
 Import('env')
 Import('env_lua')
 
+import sys
+import os
+import SCons.Script
+
+def run(cmd):
+    res = os.system(cmd)
+    if (os.WIFEXITED(res)):
+        code = os.WEXITSTATUS(res)
+        if code != 0:
+            print("Error: return code: " + str(code))
+            if SCons.Script.keep_going_on_error == 0:
+                sys.exit(code)
+
+def build_luajit():
+    if not env_lua.msvc:
+        os.chdir("luaJIT")
+        run("make clean")
+
+        if env['PLATFORM'] == 'posix' and env["platform"] == 'windows':
+            run('make HOST_CC="%s" CROSS="%s" TARGET_SYS=Windows BUILDMODE="static"' % (env['luaapi_host_cc'], env['CC'].replace("gcc", "")))
+        else:
+            run('make CC="%s" BUILDMODE="static"' % env['CC'])
+    else:
+        os.chdir("luaJIT/src")
+        run("msvcbuild static")
+
 env_lua = env_lua.Clone()
 
-env_lua.Append(CPPDEFINES='MAKE_LIB')
+if env["luaapi_luajit"]:
+    if env["luaapi_luajit_build"]:
+        build_luajit()
+    env.Append(LIBPATH=[Dir("luaJIT/src").abspath])
+    env.Append(LIBS=['libluajit'])
+    
+else:
+    env_lua.Append(CPPDEFINES='MAKE_LIB')
 
-if env_lua['PLATFORM'] == 'posix' and env["platform"] == 'linuxbsd':
-    env_lua.Append(CPPDEFINES='LUA_USE_POSIX')
+    if env['PLATFORM'] == 'posix' and env["platform"] == 'linuxbsd':
+        env_lua.Append(CPPDEFINES='LUA_USE_POSIX')
 
-if not env_lua.msvc:
-    env_lua['CFLAGS'].remove('-std=gnu11')
-    env_lua.Append(CFLAGS=['-std=c99'])
+    if not env_lua.msvc:
+        env_lua['CFLAGS'].remove('-std=gnu11')
+        env_lua.Append(CFLAGS=['-std=c99'])
 
-env_lua.add_source_files(env.modules_sources,'lua/onelua.c')
+    env_lua.add_source_files(env.modules_sources,'lua/onelua.c')
+

--- a/scripts/SConstruct
+++ b/scripts/SConstruct
@@ -38,14 +38,12 @@ if not godot_dir.exists():
 # Setup base SCons arguments to the Godot build command.
 args = ["scons"]
 for arg in ARGLIST:
+    if arg[0] == 'extra_suffix':
+        os.environ["BUILD_NAME"] = arg[1]
     opt = "%s=%s" % (arg[0], arg[1])
     args.append(opt)
 
 args.append("custom_modules=%s" % lua_dir.abspath)
-
-# Append the default `extra_suffix` to distinguish between other builds.
-args.append("extra_suffix=luaAPI")
-os.environ["BUILD_NAME"] = "luaAPI"
 
 # Avoid issues when building with different versions of Python.
 SConsignFile(".sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL))

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,3 +1,6 @@
 #!/bin/bash -e
 # we expect the working directory to be root.
 scripts/godot/bin/godot.linuxbsd.editor.x86_64.luaAPI --headless --path testing/ -s run_tests.gd
+mv testing/log.txt testing/log-lua.txt
+scripts/godot/bin/godot.linuxbsd.editor.x86_64.luaAPI.luaJIT --headless --path testing/ -s run_tests.gd
+mv testing/log.txt testing/log-luaJIT.txt

--- a/src/classes/luaThread.cpp
+++ b/src/classes/luaThread.cpp
@@ -92,12 +92,20 @@ Variant LuaThread::resume() {
     }
 
     int argc;
+    #ifndef LAPI_LUAJIT
     int ret = lua_resume(tState, NULL, 0, &argc);
+    #else
+    int ret = lua_resume(tState, 0);
+    #endif
     if (ret == LUA_OK) done = true; // thread is finished
     else if (ret != LUA_YIELD) {
         done = true;
         return state.handleError(ret);
     }
+
+    #ifdef LAPI_LUAJIT
+    argc = lua_gettop(tState);
+    #endif
     
     Array toReturn;
     for (int i = 1; i <= argc; i++) {

--- a/src/lua/lua.hpp
+++ b/src/lua/lua.hpp
@@ -1,5 +1,25 @@
+#ifndef LAPI_LUA_HPP
+#define LAPI_LUA_HPP
+
+#ifndef LAPI_LUAJIT
+
 extern "C" {
 #include <lua/lua.h>
 #include <lua/lualib.h>
 #include <lua/lauxlib.h>
 }
+
+#else
+
+#include <luaJIT/src/lua.hpp>
+
+#define LUA_OK 0
+
+inline void luaL_setmetatable(lua_State *L, const char *tname) {
+    luaL_getmetatable(L, tname);
+    lua_setmetatable(L, -2);
+}
+
+#endif
+
+#endif

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -11,7 +11,6 @@ class LuaState {
     public:
         void setState(lua_State* state, RefCounted* obj, bool bindAPI);
         void bindLibraries(Array libs);
-        void pushFunction(String functionName, Callable function, int argc, bool tuple) const;
 
         bool luaFunctionExists(String functionName);
 


### PR DESCRIPTION
This PR adds support for LuaJIT to the module. It has been added as a compile time option(`scons luaapi_luajit=yes`). LuaJIT is less portable then lua and has not been cleanly integrated into the godot build system like lua 5.4 has been. Instead we have scons call either the make or msvc build scripts provided with luaJIT. Because of this the module will still default to lua 5.4

This is still experimental and not ready to merge.