### PR TITLE
Update LICENSE

### DIFF
--- a/.github/LUA-LICENSE
+++ b/.github/LUA-LICENSE
@@ -1,7 +1,0 @@
-Copyright © 1994–2023 Lua.org, PUC-Rio.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. 

--- a/.github/workflows/gdextension.yml
+++ b/.github/workflows/gdextension.yml
@@ -195,8 +195,7 @@ jobs:
           SCONS_CACHE_LIMIT: 7168
         run: |
           rm -rf ${{ github.workspace }}/project/.g* ${{ github.workspace }}/project/project.godot ${{ github.workspace }}/project/testing ${{ github.workspace }}/project/addons/luaAPI/bin/.gitignore
-          cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' '${{ github.workspace }}/.github/LUA-LICENSE' ${{ github.workspace }}/project/addons/luaAPI
-          cp '${{ github.workspace }}/external/luaJIT/COPYRIGHT' ${{ github.workspace }}/project/addons/luaAPI/LUAJIT-LICENSE
+          cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/project/addons/luaAPI
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -94,6 +94,7 @@ jobs:
         run: |
           strip scripts/godot/bin/godot.*
           chmod +x scripts/godot/bin/godot.*
+          cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/scripts/godot/bin/
       - uses: actions/upload-artifact@v2
         with:
           name: ${{matrix.cache-name}}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -124,7 +124,9 @@ jobs:
           chmod +x app/macos_template.app/Contents/MacOS/godot_macos_release.universal
 
       - name: Prepare artifact
-        uses: actions/upload-artifact@v2
+        run: |
+          cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/scripts/godot/bin/
+      - uses: actions/upload-artifact@v2
         with:
           name: ${{matrix.cache-name}}
           path: scripts/godot/bin

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -89,6 +89,8 @@ jobs:
       - name: Prepare artifact
         run: |
           Remove-Item scripts/godot/bin/* -Include *.exp,*.lib,*.pdb -Force
+          Copy-Item '${{ github.workspace }}/README.md' -Destination ${{ github.workspace }}/scripts/godot/bin/
+          Copy-Item '${{ github.workspace }}/LICENSE' -Destination ${{ github.workspace }}/scripts/godot/bin/
       - uses: actions/upload-artifact@v2
         with:
           name: ${{matrix.cache-name}}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
-MIT License
+===============================================================================
+LuaAPI -- lua API bindings for the godot engine. 
 
-Copyright (c) 2021 Trey Moller
+Copyright (c) 2021-present Trey Moller
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +20,107 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+[ MIT license: https://www.opensource.org/licenses/mit-license.php ]
+
+===============================================================================
+[ LuaAPI includes code from Godot 4.0, which has this license statement: ]
+
+Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md).
+Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===============================================================================
+[ LuaAPI includes code from godot-cpp, which has this license statement: ]
+
+Copyright (c) 2017-present Godot Engine contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+===============================================================================
+[ LuaAPI includes code from Lua 5.1/5.2/5.4, which has this license statement: ]
+
+Copyright (C) 1994-2012 Lua.org, PUC-Rio.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+===============================================================================
+[ LuaAPI includes code from LuaJIT v2.1, which has this license statement: ]
+
+Copyright (C) 2005-2022 Mike Pall. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+===============================================================================
+[ LuaJIT includes code from dlmalloc, which has this license statement: ]
+
+This is a version (aka dlmalloc) of malloc/free/realloc written by
+Doug Lea and released to the public domain, as explained at
+https://creativecommons.org/licenses/publicdomain
+
+===============================================================================

--- a/project/project.godot
+++ b/project/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="LuaAPI Test Project"
 run/main_scene="res://testing/run_tests.tscn"
-config/features=PackedStringArray("4.1", "Mobile")
+config/features=PackedStringArray("4.0", "Mobile")
 
 [autoload]
 

--- a/scripts/run_tests.ps1
+++ b/scripts/run_tests.ps1
@@ -1,1 +1,0 @@
-godot.windows.editor.x86_64.exe --path ..\testing -s run_tests.gd

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -e
-# we expect the working directory to be root.
-scripts/godot/bin/godot.linuxbsd.editor.x86_64.luaAPI --headless --path testing/ -s run_tests.gd

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -620,12 +620,16 @@ int LuaState::luaPrint(lua_State* state)
 		String it_string;
 		
 		switch(lua_type(state, n)) {
-			case LUA_TUSERDATA:{
+			case LUA_TUSERDATA: {
 				Variant var = *(Variant*) lua_touserdata(state, n);
 				it_string = var.operator String();
 				break;
 			}
-			default:{
+            case LUA_TBOOLEAN: {
+                it_string = lua_toboolean(state, n) ? "true" : "false";
+                break;
+            }
+			default: {
 				it_string = lua_tostring(state, n);
 				break;
 			}


### PR DESCRIPTION
Updated license to include license text from third part software in use.
Updated all CI/CD to copy the license file to all artifacts.
Added case to default lua `print` method for booleans. Previously they would print blank.
Deleted unused scripts.