### PR TITLE
Fix for asset library

### DIFF
--- a/.github/workflows/gdextension.yml
+++ b/.github/workflows/gdextension.yml
@@ -196,6 +196,9 @@ jobs:
         run: |
           rm -rf ${{ github.workspace }}/project/.g* ${{ github.workspace }}/project/project.godot ${{ github.workspace }}/project/testing ${{ github.workspace }}/project/addons/luaAPI/bin/.gitignore
           cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/project/addons/luaAPI
+          mkdir ${{ github.workspace }}/project/container
+          mv ${{ github.workspace }}/project/addons/ ${{ github.workspace }}/project/container/addons/
+          mv ${{ github.workspace }}/project/demo/ ${{ github.workspace }}/project/container/demo/
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
The asset library in the editor expects there to be some containing folder. See https://github.com/godotengine/godot/issues/75712