### PR TITLE
Rename LuaThread to LuaCoroutine

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Features
 - Choose which libraries you want Lua to have access to.
 - Custom LuaCallable type which allows you to get a Lua function as a Callable. See [wiki](https://luaapi.weaselgames.info/v2.0-beta/examples/lua_callable/).
 - LuaError type which is used to report any errors this addon or Lua run into.
-- LuaThread type which creates a Lua thread. This is not a OS thread but a coroutine. 
+- LuaCoroutine type which creates a Lua thread. This is not a OS thread but a coroutine. 
 - Object passed as userdata. See [wiki](https://luaapi.weaselgames.info/v2.0-beta/examples/objects/).
 - Objects can override most of the Lua metamethods. I.E. __index by defining a function with the same name.
 - Callables passed as userdata, which allows you to push a Callable as a Lua function.

--- a/config.py
+++ b/config.py
@@ -22,7 +22,7 @@ def configure(env):
 def get_doc_classes():
     return [
         "LuaAPI",
-        "LuaThread",
+        "LuaCoroutine",
         "LuaError",
         "LuaTuple",
         "LuaCallableExtra",

--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="new_coroutine">
+			<return type="LuaCoroutine" />
+			<description>
+				This is a method that exists so you dont have to call LuaCoroutine.new() and coroutine.bind(lua) every time. It creates a new coroutine and calls bind passing lua.
+			</description>
+		</method>
 		<method name="bind_libraries">
 			<return type="void" />
 			<param index="0" name="Array" type="Array" />

--- a/doc_classes/LuaCoroutine.xml
+++ b/doc_classes/LuaCoroutine.xml
@@ -1,67 +1,52 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="LuaThread" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="LuaCoroutine" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		A coroutine.
 	</brief_description>
 	<description>
-		Binds to a existing Lua object and creates a new lua thread with lua_newthread. This is not a typical thread but a coroutine. Instead of executing a file or string directly you load it into the state. Every time the resume method is caleld the lua code will execute untill yield is called from lua.
+		Binds to a existing Lua object and creates a new lua coroutine with lua_newthread. This is not a typical thread but a coroutine. Instead of executing a file or string directly you load it into the state. Every time the resume method is caleld the lua code will execute untill yield is called from lua.
 	</description>
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="new_thread" qualifiers="static">
-			<return type="LuaThread" />
-			<param index="0" name="Lua" type="LuaAPI" />
-			<description>
-				This is a static method that exists so you dont have to call LuaThread.new() and thread.bind(lua) every time. It creates a new thread and calls bind passing lua.
-			</description>
-		</method>
 		<method name="yield_await">
 			<return type="Signal" />
 			<param index="0" name="args" type="Array" />
 			<description>
-				Allows a GDScript function being called by a LuaThread to await. It yields the lua state and passes any args to LuaThread.resume()
+				Allows a GDScript function being called by a LuaCoroutine to await. It yields the lua state and passes any args to LuaCoroutine.resume()
 			</description>
 		</method>
 		<method name="bind">
 			<return type="void" />
 			<param index="0" name="Lua" type="LuaAPI" />
 			<description>
-				Binds the thread to a lua object. All threads attached to the same object share resources.
+				Binds the coroutine to a lua object. All coroutines attached to the same object share resources.
 			</description>
 		</method>
 		<method name="load_file">
 			<return type="LuaError" />
 			<param index="0" name="FilePath" type="String" />
 			<description>
-				Loads a file into the threads state.
+				Loads a file into the coroutines state.
 			</description>
 		</method>
 		<method name="load_string">
 			<return type="void" />
 			<param index="0" name="Code" type="String" />
 			<description>
-				Loads a string into the threads state.
+				Loads a string into the coroutines state.
 			</description>
 		</method>
 		<method name="resume">
 			<return type="Variant" />
 			<description>
-				Resumes or starts the thread. Will either return a Array of arguments passed by lua in yield() or a LuaError.
+				Resumes or starts the coroutine. Will either return a Array of arguments passed by lua in yield() or a LuaError.
 			</description>
 		</method>
 		<method name="is_done">
 			<return type="bool" />
 			<description>
-				Returns true if the thread is finished executing.
-			</description>
-		</method>
-		<method name="expose_constructor">
-			<return type="LuaError" />
-			<param index="0" name="LuaConstructorName" type="String" />
-			<param index="1" name="Object" type="Object" />
-			<description>
-				Accepts any object that has a new() method. Allows lua to call the contructor aka the new() method. Exposed as a global with the given name.
+				Returns true if the coroutine is finished executing.
 			</description>
 		</method>
 		<method name="function_exists">

--- a/project/demo/HelloLua.gd
+++ b/project/demo/HelloLua.gd
@@ -22,7 +22,7 @@ func _ready():
 		return "Hello gdScript!"
 	end
 	""")
-	print(err)
+	
 	if err is LuaError:
 		print("ERROR %d: %s" % [err.type, err.message])
 		return

--- a/project/testing/tests/LuaCoroutine.resume.gd
+++ b/project/testing/tests/LuaCoroutine.resume.gd
@@ -1,41 +1,33 @@
 extends UnitTest
 var lua: LuaAPI
-var thread: LuaThread
-
-func _test_yield_await()->int:
-	await thread.yield_await([get_tree().create_timer(3).timeout])
-	return 4
+var co: LuaCoroutine
 
 func _ready():
 	# Since we are using poly here, we need to make sure to call super for _methods
 	super._ready()
 	# id will determine the load order
-	id = 9490
+	id = 9500
 
 	lua = LuaAPI.new()
-	thread = LuaThread.new_thread(lua)
-	thread.push_variant("test_yield_await", _test_yield_await)
+	co = lua.new_coroutine()
 	
-	thread.load_string("
+	co.load_string("
 	a = 0
 	for i=1,10,1 do
 		-- yield is exposed to Lua when the thread is bound.
 		yield(1)
 		a = a + i
 	end
-	b = test_yield_await()
 	")
 	
 	# testName and testDescription are for any needed context about the test.
-	testName = "LuaThread.yield_await"
+	testName = "LuaCoroutine.resume"
 	testDescription = "
-Runs a lua thrad yielding for 1 secound. It will run 10 times.
+Runs a lua coroutine yielding for 1 secound. It will run 10 times.
 a = 0
 for each resume
 	a = a + i
 a should be 55
-After which it calls _test_yield_await and sets b to its return.
-b should be 4
 "
 
 func fail():
@@ -44,19 +36,21 @@ func fail():
 
 var yieldTime = 0
 var timeSince = 0
-var proc = true
 func _process(delta):
 	# Since we are using poly here, we need to make sure to call super for _methods
 	super._process(delta)
-	if not proc:
-		return
 	
 	timeSince += delta
 	if timeSince <= yieldTime:
 		return
+	
+	var ret = co.resume()
+	if ret is LuaError:
+		errors.append(ret)
+		return fail()
 		
-	if thread.is_done():
-		var a = thread.pull_variant("a")
+	if co.is_done():
+		var a = co.pull_variant("a")
 		if a is LuaError:
 			errors.append(a)
 			return fail()
@@ -64,42 +58,20 @@ func _process(delta):
 		if not a == 55:
 			errors.append(LuaError.new_error("a is not 55 but is '%d'" % a))
 			return fail()
-
-		var b = thread.pull_variant("b")
-		if b is LuaError:
-			errors.append(b)
-			return fail()
 		
-		if not b == 4:
-			errors.append(LuaError.new_error("b is not 4 but is '%d'" % b))
-			return fail()
-		
-		if time < 13 or time > 13.1:
-			errors.append(LuaError.new_error("time is not within 13 and 13.1 but is '%s'" % str(time)))
+		if time < 10 or time > 10.1:
+			errors.append(LuaError.new_error("time is not within 10 and 10.1 but is '%s'" % str(time)))
 			return fail()
 		
 		done = true
 		return
 	
-	var ret = thread.resume()
-	if ret is LuaError:
-		errors.append(ret)
-		return fail()
-	
 	if not ret is Array:
 		errors.append(LuaError.new_error("Result is not Array but is '%d'" % typeof(ret), LuaError.ERR_TYPE))
 		return fail()
-	if  ret.size() == 0:
-		return
 	if not ret.size() == 1:
 		errors.append(LuaError.new_error("Result.size() is not 1 but is '%d'" % ret.size()))
 		return fail()
-	
-	if ret[0] is Signal:
-		proc = false
-		await ret[0]
-		proc = true
-		return
 	
 	yieldTime = ret[0]
 	

--- a/project/testing/tests/LuaCoroutine.yield_await.gd
+++ b/project/testing/tests/LuaCoroutine.yield_await.gd
@@ -1,33 +1,41 @@
 extends UnitTest
 var lua: LuaAPI
-var thread: LuaThread
+var co: LuaCoroutine
+
+func _test_yield_await()->int:
+	await co.yield_await([get_tree().create_timer(3).timeout])
+	return 4
 
 func _ready():
 	# Since we are using poly here, we need to make sure to call super for _methods
 	super._ready()
 	# id will determine the load order
-	id = 9500
+	id = 9490
 
 	lua = LuaAPI.new()
-	thread = LuaThread.new_thread(lua)
+	co = lua.new_coroutine()
+	co.push_variant("test_yield_await", _test_yield_await)
 	
-	thread.load_string("
+	co.load_string("
 	a = 0
 	for i=1,10,1 do
 		-- yield is exposed to Lua when the thread is bound.
 		yield(1)
 		a = a + i
 	end
+	b = test_yield_await()
 	")
 	
 	# testName and testDescription are for any needed context about the test.
-	testName = "LuaThread.resume"
+	testName = "LuaCoroutine.yield_await"
 	testDescription = "
 Runs a lua thrad yielding for 1 secound. It will run 10 times.
 a = 0
 for each resume
 	a = a + i
 a should be 55
+After which it calls _test_yield_await and sets b to its return.
+b should be 4
 "
 
 func fail():
@@ -36,21 +44,19 @@ func fail():
 
 var yieldTime = 0
 var timeSince = 0
+var proc = true
 func _process(delta):
 	# Since we are using poly here, we need to make sure to call super for _methods
 	super._process(delta)
+	if not proc:
+		return
 	
 	timeSince += delta
 	if timeSince <= yieldTime:
 		return
-	
-	var ret = thread.resume()
-	if ret is LuaError:
-		errors.append(ret)
-		return fail()
 		
-	if thread.is_done():
-		var a = thread.pull_variant("a")
+	if co.is_done():
+		var a = co.pull_variant("a")
 		if a is LuaError:
 			errors.append(a)
 			return fail()
@@ -58,20 +64,42 @@ func _process(delta):
 		if not a == 55:
 			errors.append(LuaError.new_error("a is not 55 but is '%d'" % a))
 			return fail()
+
+		var b = co.pull_variant("b")
+		if b is LuaError:
+			errors.append(b)
+			return fail()
 		
-		if time < 10 or time > 10.1:
-			errors.append(LuaError.new_error("time is not within 10 and 10.1 but is '%s'" % str(time)))
+		if not b == 4:
+			errors.append(LuaError.new_error("b is not 4 but is '%d'" % b))
+			return fail()
+		
+		if time < 13 or time > 13.1:
+			errors.append(LuaError.new_error("time is not within 13 and 13.1 but is '%s'" % str(time)))
 			return fail()
 		
 		done = true
 		return
 	
+	var ret = co.resume()
+	if ret is LuaError:
+		errors.append(ret)
+		return fail()
+	
 	if not ret is Array:
 		errors.append(LuaError.new_error("Result is not Array but is '%d'" % typeof(ret), LuaError.ERR_TYPE))
 		return fail()
+	if  ret.size() == 0:
+		return
 	if not ret.size() == 1:
 		errors.append(LuaError.new_error("Result.size() is not 1 but is '%d'" % ret.size()))
 		return fail()
+	
+	if ret[0] is Signal:
+		proc = false
+		await ret[0]
+		proc = true
+		return
 	
 	yieldTime = ret[0]
 	

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -1,7 +1,7 @@
 #include "register_types.h"
 #include "src/classes/luaAPI.h"
 #include "src/classes/luaError.h"
-#include "src/classes/luaThread.h"
+#include "src/classes/luaCoroutine.h"
 #include "src/classes/luaCallable.h"
 #include "src/classes/luaTuple.h"
 #include "src/classes/luaCallableExtra.h"
@@ -15,7 +15,7 @@ void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 		return;
 	
 	ClassDB::register_class<LuaAPI>();
-	ClassDB::register_class<LuaThread>();
+	ClassDB::register_class<LuaCoroutine>();
 	ClassDB::register_class<LuaError>();
 	ClassDB::register_class<LuaTuple>();
 	ClassDB::register_class<LuaCallableExtra>();

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -1,5 +1,6 @@
 #include "luaAPI.h"
 
+#include "luaCoroutine.h"
 
 #ifdef LAPI_GDEXTENSION
 #include <godot_cpp/classes/file_access.hpp>
@@ -30,16 +31,13 @@ void LuaAPI::_bind_methods() {
     ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
     ClassDB::bind_method(D_METHOD("call_function", "LuaFunctionName", "Args"), &LuaAPI::callFunction);
     ClassDB::bind_method(D_METHOD("function_exists", "LuaFunctionName"), &LuaAPI::luaFunctionExists);
+
+    ClassDB::bind_method(D_METHOD("new_coroutine"), &LuaAPI::newCoroutine);
 }
 
 // Calls LuaState::bindLibs()
 void LuaAPI::bindLibraries(Array libs) {
     state.bindLibraries(libs);
-}
-
-// Adds the pointer to a object now owned by lua for cleanup later
-void LuaAPI::addOwnedObject(void* luaPtr, Variant* obj) {
-    ownedObjects[luaPtr] = obj;
 }
 
 // Calls LuaState::luaFunctionExists()
@@ -122,8 +120,15 @@ LuaError* LuaAPI::execute(int handlerIndex) {
     return nullptr;
 }
 
+Ref<LuaCoroutine> LuaAPI::newCoroutine() {
+    Ref<LuaCoroutine> thread;
+    thread.instantiate();
+    thread->bind(this);
+    return thread;
+}
+
 // Creates a new thread staee
-lua_State* LuaAPI::newThread() {
+lua_State* LuaAPI::newThreadState() {
     return lua_newthread(lState);
 }
 

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -20,6 +20,8 @@
 using namespace godot;
 #endif
 
+class LuaCoroutine;
+
 class LuaAPI : public RefCounted {
     GDCLASS(LuaAPI, RefCounted);
 
@@ -31,7 +33,6 @@ class LuaAPI : public RefCounted {
         ~LuaAPI();
 
         void bindLibraries(Array libs);
-        void addOwnedObject(void* luaPtr, Variant* obj);
 
         bool luaFunctionExists(String functionName);
 
@@ -42,20 +43,28 @@ class LuaAPI : public RefCounted {
         LuaError* doString(String code);
         LuaError* pushGlobalVariant(String name, Variant var);
         LuaError* exposeObjectConstructor(String name, Object* obj);
+
+        Ref<LuaCoroutine> newCoroutine();
         
-        lua_State* newThread();
+        lua_State* newThreadState();
         lua_State* getState();
 
         inline void addRef(Variant var) {
             refs.append(var);
         }
 
+        inline void addOwnedObject(void* luaPtr, Variant* obj) {
+            ownedObjects[luaPtr] = obj;
+        }
+
     private:
         LuaState state;
         lua_State* lState;
-        // Temp. Looking for better method
+
+        // Temp. Looking for better method. Maybe?
         Array refs;
         std::map<void*, Variant*> ownedObjects;
+
         LuaError* execute(int handlerIndex);
 };
 

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -1,5 +1,5 @@
-#ifndef LUATHREAD_H
-#define LUATHREAD_H
+#ifndef LUACOROUTINE_H
+#define LUACOROUTINE_H
 
 #include "luaError.h" 
 
@@ -19,16 +19,15 @@ using namespace godot;
 
 class LuaAPI;
 
-class LuaThread : public RefCounted {
-    GDCLASS(LuaThread, RefCounted);
+class LuaCoroutine : public RefCounted {
+    GDCLASS(LuaCoroutine, RefCounted);
 
     protected:
         static void _bind_methods();
 
     public:
-        static LuaThread* newThread(Ref<LuaAPI> lua);
-
         void bind(Ref<LuaAPI> lua);
+        void bindExisting(Ref<LuaAPI> lua, lua_State* tState);
         void loadString(String code);
         Signal yieldAwait(Array args);
 
@@ -36,7 +35,8 @@ class LuaThread : public RefCounted {
 
         LuaError* loadFile(String fileName);
         LuaError* pushGlobalVariant(String name, Variant var);
-        LuaError* exposeObjectConstructor(String name, Object* obj);
+
+        Ref<LuaAPI> getParent();
 
         Variant resume();
         Variant pullVariant(String name);
@@ -45,11 +45,15 @@ class LuaThread : public RefCounted {
         bool isDone();
         
         static int luaYield(lua_State *state);
+
+        inline lua_State* getLuaState() {
+            return tState;
+        }
+
     private:
         LuaState state;
         Ref<LuaAPI> parent;
         lua_State* tState;
-        lua_State* parentState;
         bool done;
 };
 


### PR DESCRIPTION
Mostly resolves #95, I chose not to have the parent lua state keep track of threads. Seemed unneeded.
This PR renames LuaThread to LuaCoroutine in favor of being less confusing.

### Also added:
- Support to pull coroutines created via coroutine.create as a LuaCoroutine. I could not get pushing LuaCourtines working however. For some reason it just would not work. Hopefully a fix can be found in the future.
- new method on the LuaAPI class new_coroutine, which takes no arguments and returns a LuaCoroutine
### Removed:
- the new_thread static method has been removed from the LuaThread/LuaCoroutine class in favor of the new method on LuaAPI.

### Before merge
Online documentation needs to be updated to reflect changes.