### PR TITLE
Improve error handling

### DIFF
--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -104,7 +104,11 @@ LuaError* LuaAPI::doFile(String fileName) {
 LuaError* LuaAPI::doString(String code) {
     // push the error handler onto the stack
     lua_pushcfunction(lState, LuaState::luaErrorHandler);
-    luaL_loadstring(lState, code.ascii().get_data());
+    int ret = luaL_loadstring(lState, code.ascii().get_data());
+    if (ret != LUA_OK) {
+        return state.handleError(ret);
+    }
+    
     LuaError* err = execute(-2);
     // pop the error handler from the stack
     lua_pop(lState, 1);

--- a/src/classes/luaCallable.cpp
+++ b/src/classes/luaCallable.cpp
@@ -46,6 +46,8 @@ uint32_t LuaCallable::hash() const {
 }
 
 void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	lua_pushcfunction(state, LuaState::luaErrorHandler);
+	
 	// Geting the lua function via the referance stored in funcRef
 	lua_rawgeti(state, LUA_REGISTRYINDEX, funcRef);
 
@@ -55,7 +57,7 @@ void LuaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_r
 	}
 
 	// execute the function using a protected call.
-	int ret = lua_pcall(state, p_argcount, 1, 0);
+	int ret = lua_pcall(state, p_argcount, 1, -2 - p_argcount);
     if (ret != LUA_OK) {
         r_return_value = LuaState::handleError(state, ret);
     } else r_return_value = LuaState::getVariant(state, -1, obj.ptr());


### PR DESCRIPTION
Resolves #101 
Currently we do not capture errors returned from loading code as a string in LuaAPI::doString. We also do not set an error handler for the pcall in luaCallable. This will help increase the error message consistency and quality.