### PR TITLE
Handle LuaCouroutine load_string errors

### DIFF
--- a/doc_classes/LuaCoroutine.xml
+++ b/doc_classes/LuaCoroutine.xml
@@ -31,7 +31,7 @@
 			</description>
 		</method>
 		<method name="load_string">
-			<return type="void" />
+			<return type="LuaError" />
 			<param index="0" name="Code" type="String" />
 			<description>
 				Loads a string into the coroutines state.

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -85,9 +85,13 @@ Ref<LuaAPI> LuaCoroutine::getParent() {
 }
 
 // loads a string into the threads state
-void LuaCoroutine::loadString(String code) {
+LuaError* LuaCoroutine::loadString(String code) {
     done = false;
-    luaL_loadstring(tState, code.ascii().get_data());
+    int ret = luaL_loadstring(tState, code.ascii().get_data());
+    if (ret != LUA_OK) {
+        return state.handleError(ret);
+    }
+    return nullptr;
 }
 
 

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -28,11 +28,11 @@ class LuaCoroutine : public RefCounted {
     public:
         void bind(Ref<LuaAPI> lua);
         void bindExisting(Ref<LuaAPI> lua, lua_State* tState);
-        void loadString(String code);
         Signal yieldAwait(Array args);
 
         bool luaFunctionExists(String functionName);
 
+        LuaError* loadString(String code);
         LuaError* loadFile(String fileName);
         LuaError* pushGlobalVariant(String name, Variant var);
 

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -115,7 +115,6 @@ void LuaState::exposeConstructors() {
         return 1;
     }));
     lua_setglobal(L, "Plane");
-    
 }
 
 // Create metatable for Vector2 and saves it at LUA_REGISTRYINDEX with name "mt_Vector2"


### PR DESCRIPTION
Previously LuaCoroutine.load_string would not handle an error if one occurred. This PR fixes that.