### PR TITLE
Create interrupt_execution and kill methods on LuaCoroutine

### DIFF
--- a/doc_classes/LuaCoroutine.xml
+++ b/doc_classes/LuaCoroutine.xml
@@ -85,5 +85,17 @@
 				Pauses execution (if running/next time it resumes) by binding a new debug hook and yielding.
 			</description>
 		</method>
+		<method name="interrupt_execution">
+			<return type="void" />
+			<description>
+				Interrupts execution (if running/next time it resumes) by binding a new debug hook and throwing the error [code]execution interrupted[/code].
+			</description>
+		</method>
+		<method name="kill">
+			<return type="void" />
+			<description>
+				Kills the thread (if running/next time it resumes) by throwing repeated errors until it gets to the top of the stack, exiting.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -160,7 +160,10 @@ Variant LuaCoroutine::resume() {
         #endif
     }
     
-    
+    if (killing) {
+        killing = false;
+        lua_sethook(tState, nullptr, NULL, NULL); // clean up after thread killed
+    }
     
     if (ret == LUA_OK) done = true; // thread is finished
     else if (ret != LUA_YIELD) {
@@ -209,7 +212,10 @@ void LuaCoroutine::interrupt_hook(lua_State* tState,lua_Debug* dbg) {
 }
 
 void LuaCoroutine::kill() {
-    if (!done) lua_sethook(tState, terminate_hook, LUA_MASKCOUNT, 1); // force it to run next time
+    if (!done) {
+        lua_sethook(tState, terminate_hook, LUA_MASKCOUNT, 1); // force it to run next time
+        killing = true;
+    }
 }
 
 void LuaCoroutine::terminate_hook(lua_State* tState,lua_Debug* dbg) {

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -207,7 +207,7 @@ void LuaCoroutine::interrupt_execution() {
 
 void LuaCoroutine::interrupt_hook(lua_State* tState,lua_Debug* dbg) {
    lua_sethook(tState, nullptr, NULL, NULL); // remove hook
-   lua_pushstring(tState,"execution interrupted");
+   lua_pushstring(tState, "execution interrupted");
    lua_error(tState);
 }
 

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -218,7 +218,7 @@ void LuaCoroutine::kill() {
     }
 }
 
-void LuaCoroutine::terminate_hook(lua_State* tState,lua_Debug* dbg) {
-   lua_pushstring(tState,"execution terminated");
+void LuaCoroutine::terminate_hook(lua_State* tState, lua_Debug* dbg) {
+   lua_pushstring(tState, "execution terminated");
    lua_error(tState);
 }

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -64,6 +64,7 @@ class LuaCoroutine : public RefCounted {
         Ref<LuaAPI> parent;
         lua_State* tState;
         bool done;
+        bool killing;
 };
 
 #endif

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -47,7 +47,13 @@ class LuaCoroutine : public RefCounted {
         static int luaYield(lua_State *state);
     
         void pause_execution();
-        static void terminate_hook(lua_State*, lua_Debug*);
+        static void pause_hook(lua_State*, lua_Debug*);
+    
+        void interrupt_execution();
+        static void interrupt_hook(lua_State*, lua_Debug*);
+    
+        void kill(); //is the lua thread still resisting? while trues in pcalls in while trues?
+        static void terminate_hook(lua_State*, lua_Debug*); // no problem! Just chop its head off :] Repeatedly throws errors.
 
         inline lua_State* getLuaState() {
             return tState;


### PR DESCRIPTION
Already documented:

`interrupt_execution()` will throw an error `execution interrupted`

`kill()` will throw an error `execution terminated` and will not stop until the thread exits all the way to the top stack.