### PR TITLE
Add methods get_running_coroutine,set_hook and yield_state

### DIFF
--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -15,6 +15,12 @@
 				This method will create a coroutine that is already bound to this runtime.
 			</description>
 		</method>
+		<method name="get_running_coroutine">
+			<return type="LuaCoroutine" />
+			<description>
+				Intended to be called from a lua hook. Returns the current running coroutine.
+			</description>
+		</method>
 		<method name="bind_libraries">
 			<return type="void" />
 			<param index="0" name="Array" type="Array" />
@@ -74,5 +80,28 @@
 				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
 			</description>
 		</method>
+		<method name="set_hook">
+			<return type="void" />
+			<param index="0" name="hook" type="Callable" />
+			<param index="1" name="mask" type="int" />
+			<param index="1" name="count" type="int" />
+			<description>
+				Sets the hook for the state. The hook will be called on the events specified by the mask. The count specifies how many instructions should be executed before the hook is called. If count is 0, the hook will be called on every instruction. The hook will be called with the following arguments: [code]hook(parent, event, line)[/code]. The parent is the LuaAPI object that owns the current state.
+			</description>
+		</method>
 	</methods>
+	<constants>
+		<constant name="HOOK_MASK_CALL" value="1" enum="HookMask">
+			Specifies on which events the hook will be called.
+		</constant>
+		<constant name="HOOK_MASK_RETURN" value="2" enum="HookMask">
+			Specifies on which events the hook will be called.
+		</constant>
+		<constant name="HOOK_MASK_LINE" value="3" enum="HookMask">
+			Specifies on which events the hook will be called.
+		</constant>
+		<constant name="HOOK_MASK_COUNT" value="4" enum="HookMask">
+			Specifies on which events the hook will be called.
+		</constant>
+	</constants>
 </class>

--- a/doc_classes/LuaCoroutine.xml
+++ b/doc_classes/LuaCoroutine.xml
@@ -16,6 +16,13 @@
 				Allows a GDScript function being called by a LuaCoroutine to await. It yields the lua state and passes any args to LuaCoroutine.resume()
 			</description>
 		</method>
+		<method name="yield_state">
+			<return type="LuaError" />
+			<param index="0" name="args" type="Array" />
+			<description>
+				Must be called from a lua hook. Will yield the lua state and pass arguments to `reumse()`. Can be destructive.
+			</description>
+		</method>
 		<method name="bind">
 			<return type="void" />
 			<param index="0" name="Lua" type="LuaAPI" />
@@ -79,22 +86,13 @@
 				Will push a copy of a Variant to lua as a global. Returns a error if the type is not supported.
 			</description>
 		</method>
-		<method name="pause_execution">
+		<method name="set_hook">
 			<return type="void" />
+			<param index="0" name="hook" type="Callable" />
+			<param index="1" name="mask" type="int" />
+			<param index="1" name="count" type="int" />
 			<description>
-				Pauses execution (if running/next time it resumes) by binding a new debug hook and yielding.
-			</description>
-		</method>
-		<method name="interrupt_execution">
-			<return type="void" />
-			<description>
-				Interrupts execution (if running/next time it resumes) by binding a new debug hook and throwing the error [code]execution interrupted[/code].
-			</description>
-		</method>
-		<method name="kill">
-			<return type="void" />
-			<description>
-				Kills the thread (if running/next time it resumes) by throwing repeated errors until it gets to the top of the stack, exiting.
+				Sets the hook for the state. The hook will be called on the events specified by the mask. The count specifies how many instructions should be executed before the hook is called. If count is 0, the hook will be called on every instruction. The hook will be called with the following arguments: [code]hook(parent, event, line)[/code]. The parent is the LuaAPI object that owns the current state.
 			</description>
 		</method>
 	</methods>

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -33,6 +33,7 @@ class LuaAPI : public RefCounted {
         ~LuaAPI();
 
         void bindLibraries(Array libs);
+        void setHook(Callable hook, int mask, int count);
 
         bool luaFunctionExists(String functionName);
 
@@ -45,6 +46,7 @@ class LuaAPI : public RefCounted {
         LuaError* exposeObjectConstructor(String name, Object* obj);
 
         Ref<LuaCoroutine> newCoroutine();
+        Ref<LuaCoroutine> getRunningCoroutine();
         
         lua_State* newThreadState();
         lua_State* getState();
@@ -57,6 +59,13 @@ class LuaAPI : public RefCounted {
             ownedObjects[luaPtr] = obj;
         }
 
+        enum HookMask{
+            HOOK_MASK_CALL      = LUA_MASKCALL,
+            HOOK_MASK_RETURN    = LUA_MASKRET,
+            HOOK_MASK_LINE      = LUA_MASKLINE,
+            HOOK_MASK_COUNT     = LUA_MASKCOUNT,
+        };
+
     private:
         LuaState state;
         lua_State* lState;
@@ -67,5 +76,7 @@ class LuaAPI : public RefCounted {
 
         LuaError* execute(int handlerIndex);
 };
+
+VARIANT_ENUM_CAST(LuaAPI::HookMask)
 
 #endif

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -10,8 +10,10 @@
 
 void LuaCoroutine::_bind_methods() {
     ClassDB::bind_method(D_METHOD("bind", "lua"), &LuaCoroutine::bind);
+    ClassDB::bind_method(D_METHOD("set_hook", "Hook", "HookMask", "Count"), &LuaCoroutine::setHook);
     ClassDB::bind_method(D_METHOD("resume"), &LuaCoroutine::resume);
-    ClassDB::bind_method(D_METHOD("yield_await", "signal"), &LuaCoroutine::yieldAwait);
+    ClassDB::bind_method(D_METHOD("yield_await", "Args"), &LuaCoroutine::yieldAwait);
+    ClassDB::bind_method(D_METHOD("yield_state", "Args"), &LuaCoroutine::yield);
 
     ClassDB::bind_method(D_METHOD("load_string", "Code"), &LuaCoroutine::loadString);
     ClassDB::bind_method(D_METHOD("load_file", "FilePath"), &LuaCoroutine::loadFile);
@@ -22,14 +24,33 @@ void LuaCoroutine::_bind_methods() {
     ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaCoroutine::pushGlobalVariant);
     ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaCoroutine::pullVariant);
     
-    ClassDB::bind_method(D_METHOD("pause_execution"), &LuaCoroutine::pause_execution);
-    ClassDB::bind_method(D_METHOD("interrupt_execution"), &LuaCoroutine::interrupt_execution);
-    ClassDB::bind_method(D_METHOD("kill"), &LuaCoroutine::kill);
-    
     // This is a dummy signal never meant to actually be emited. Await needs with a coroutine or a signal to work. Even though we resume it via the GDScriptFunctionState
     ADD_SIGNAL(MethodInfo("coroutine_resume"));
+}
 
+// binds the thread to a lua object
+void LuaCoroutine::bind(Ref<LuaAPI> lua) {
+    parent = lua;
+    tState = lua->newThreadState();
+    state.setState(tState, this, false);
+    
+    // register the yield method
+    lua_register(tState, "yield", luaYield);
+}
 
+// binds the thread to a lua object
+void LuaCoroutine::bindExisting(Ref<LuaAPI> lua, lua_State* tState) {
+    done = false;
+    parent = lua;
+    this->tState = tState;
+    state.setState(tState, this, false);
+    
+    // register the yield method
+    lua_register(tState, "yield", luaYield);
+}
+
+void LuaCoroutine::setHook(Callable hook, int mask, int count) {
+    return state.setHook(hook, mask, count);
 }
 
 Signal LuaCoroutine::yieldAwait(Array args) {
@@ -61,27 +82,6 @@ LuaError* LuaCoroutine::pushGlobalVariant(String name, Variant var) {
 // Calls LuaState::callFunction()
 Variant LuaCoroutine::callFunction(String functionName, Array args) {
     return state.callFunction(functionName, args);
-}
-
-// binds the thread to a lua object
-void LuaCoroutine::bind(Ref<LuaAPI> lua) {
-    parent = lua;
-    tState = lua->newThreadState();
-    state.setState(tState, this, false);
-    
-    // register the yield method
-    lua_register(tState, "yield", luaYield);
-}
-
-// binds the thread to a lua object
-void LuaCoroutine::bindExisting(Ref<LuaAPI> lua, lua_State* tState) {
-    done = false;
-    parent = lua;
-    this->tState = tState;
-    state.setState(tState, this, false);
-    
-    // register the yield method
-    lua_register(tState, "yield", luaYield);
 }
 
 Ref<LuaAPI> LuaCoroutine::getParent() { 
@@ -123,8 +123,22 @@ LuaError* LuaCoroutine::loadFile(String fileName) {
     return nullptr;
 }
 
-// Value 1 will always be a boolean which indicates weather the thread is done or not.
-// If a error occures it will be value number 2, otherwise the rest of the values are arguments passed to yield()
+LuaError* LuaCoroutine::yield(Array args) {
+    Array ret;
+    if (int count = lua_gettop(tState); count > 0) {
+        lua_pop(tState, count);
+    }
+    for (int i = 0; i < args.size(); i++) {
+        LuaError* err = state.pushVariant(args[i]);
+        if (err != nullptr) {
+            return err;
+        }
+    }
+
+    lua_yield(tState, args.size());
+    return nullptr;
+}
+
 Variant LuaCoroutine::resume() {
     if (done) {
         return LuaError::newError("Thread is done executing", LuaError::ERR_RUNTIME);
@@ -164,11 +178,6 @@ Variant LuaCoroutine::resume() {
         #endif
     }
     
-    if (killing) {
-        killing = false;
-        lua_sethook(tState, nullptr, NULL, NULL); // clean up after thread killed
-    }
-    
     if (ret == LUA_OK) done = true; // thread is finished
     else if (ret != LUA_YIELD) {
         done = true;
@@ -194,35 +203,4 @@ bool LuaCoroutine::isDone() {
 int LuaCoroutine::luaYield(lua_State *state) {
     int argc = lua_gettop(state);
     return lua_yield(state, argc);
-}
-
-void LuaCoroutine::pause_execution() {
-    if (!done) lua_sethook(tState, pause_hook, LUA_MASKCOUNT, 1); // force it to run next time
-}
-
-void LuaCoroutine::pause_hook(lua_State* tState,lua_Debug* dbg) {
-   lua_sethook(tState, nullptr, NULL, NULL); // remove hook
-   lua_yield(tState, 0);
-}
-
-void LuaCoroutine::interrupt_execution() {
-    if (!done) lua_sethook(tState, interrupt_hook, LUA_MASKCOUNT, 1); // force it to run next time
-}
-
-void LuaCoroutine::interrupt_hook(lua_State* tState,lua_Debug* dbg) {
-   lua_sethook(tState, nullptr, NULL, NULL); // remove hook
-   lua_pushstring(tState, "execution interrupted");
-   lua_error(tState);
-}
-
-void LuaCoroutine::kill() {
-    if (!done) {
-        lua_sethook(tState, terminate_hook, LUA_MASKCOUNT, 1); // force it to run next time
-        killing = true;
-    }
-}
-
-void LuaCoroutine::terminate_hook(lua_State* tState, lua_Debug* dbg) {
-   lua_pushstring(tState, "execution terminated");
-   lua_error(tState);
 }

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -28,6 +28,8 @@ class LuaCoroutine : public RefCounted {
     public:
         void bind(Ref<LuaAPI> lua);
         void bindExisting(Ref<LuaAPI> lua, lua_State* tState);
+        void setHook(Callable hook, int mask, int count);
+
         Signal yieldAwait(Array args);
 
         bool luaFunctionExists(String functionName);
@@ -35,6 +37,7 @@ class LuaCoroutine : public RefCounted {
         LuaError* loadString(String code);
         LuaError* loadFile(String fileName);
         LuaError* pushGlobalVariant(String name, Variant var);
+        LuaError* yield(Array args);
 
         Ref<LuaAPI> getParent();
 
@@ -45,15 +48,7 @@ class LuaCoroutine : public RefCounted {
         bool isDone();
         
         static int luaYield(lua_State *state);
-    
-        void pause_execution();
-        static void pause_hook(lua_State*, lua_Debug*);
-    
-        void interrupt_execution();
-        static void interrupt_hook(lua_State*, lua_Debug*);
-    
-        void kill(); //is the lua thread still resisting? while trues in pcalls in while trues?
-        static void terminate_hook(lua_State*, lua_Debug*); // no problem! Just chop its head off :] Repeatedly throws errors.
+        static void luaHook(lua_State *state, lua_Debug *ar);
 
         inline lua_State* getLuaState() {
             return tState;
@@ -64,7 +59,6 @@ class LuaCoroutine : public RefCounted {
         Ref<LuaAPI> parent;
         lua_State* tState;
         bool done;
-        bool killing;
 };
 
 #endif

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -141,6 +141,18 @@ void LuaState::bindLibraries(Array libs) {
 
 #endif
 
+void LuaState::setHook(Callable hook, int mask, int count) {
+    if (hook.is_null()) {
+        lua_sethook(L, nullptr, 0, 0);
+        return;
+    }
+
+    lua_pushstring(L, "__HOOK");
+    pushVariant(hook);
+    lua_settable(L, LUA_REGISTRYINDEX);
+    lua_sethook(L, LuaCoroutine::luaHook, mask, count);
+}
+
 // Returns true if a lua function exists with the given name
 bool LuaState::luaFunctionExists(String functionName) {
     // LuaJIT does not return a type here
@@ -747,7 +759,6 @@ int LuaState::luaCallableCall(lua_State* state) {
     Array args;
     int index = 2; // we start at 2, 1 is the callable
     for (int i = 0; i < argc; i++) {
-        
         Variant var = LuaState::getVariant(state, index++, OBJ);
         if (var.get_type() == Variant::Type::OBJECT) {
             if (LuaError* err = dynamic_cast<LuaError*>(var.operator Object*()); err != nullptr) {
@@ -786,7 +797,7 @@ int LuaState::luaCallableCall(lua_State* state) {
 // This function is invoked whenever a function is called on one of the userdata types 
 // excluding mt_Callable or mt_Object if __index is overwritten
 int LuaState::luaUserdataFuncCall(lua_State* state) {
-        lua_pushstring(state, "__OBJECT");
+    lua_pushstring(state, "__OBJECT");
     lua_rawget(state, LUA_REGISTRYINDEX);
     RefCounted* OBJ = (RefCounted*) lua_touserdata(state, -1);
     lua_pop(state, 1);
@@ -835,4 +846,61 @@ int LuaState::luaUserdataFuncCall(lua_State* state) {
     #endif
         return tuple->size();
     return 1;
+}
+
+void LuaCoroutine::luaHook(lua_State* state, lua_Debug* ar) {
+    lua_pushstring(state, "__OBJECT");
+    lua_rawget(state, LUA_REGISTRYINDEX);
+    RefCounted* OBJ = (RefCounted*) lua_touserdata(state, -1);
+    lua_pop(state, 1);
+
+    lua_pushstring(state, "__HOOK");
+    lua_rawget(state, LUA_REGISTRYINDEX);
+    Callable hook = LuaState::getVariant(state, -1, OBJ);
+    lua_pop(state, 1);
+
+    if (hook.is_null()) {
+        return;
+    }
+
+    #ifndef LAPI_GDEXTENSION
+    Array p_args;
+    p_args.append(OBJ);
+    p_args.append(ar->event);
+    p_args.append(ar->currentline);    
+
+    const Variant **args = (const Variant**)alloca(sizeof(const Variant**) * p_args.size());
+    for (int i = 0; i < p_args.size(); i++) {
+        args[i] = &p_args[i];
+    }
+
+    Variant returned;
+    Callable::CallError error;
+    hook.callp(args, p_args.size(), returned, error);
+    if (error.error != error.CALL_OK) {
+        LuaError* err = LuaState::handleError(hook.get_method(), error, args, p_args.size());
+        lua_pushstring(state, err->getMessage().ascii().get_data());
+        lua_error(state);
+        return;
+    }
+
+    LuaError* err = LuaState::pushVariant(state, returned);
+    if (err != nullptr) {
+        lua_pushstring(state, err->getMessage().ascii().get_data());
+        lua_error(state);
+    }
+    #else
+    Array args;
+    args.append(OBJ);
+    args.append(ar->event);
+    args.append(ar->currentline);
+
+    
+    Variant returned = hook.callv(args);
+    LuaError* err = LuaState::pushVariant(state, returned);
+    if (err != nullptr) {
+        lua_pushstring(state, err->getMessage().ascii().get_data());
+        lua_error(state);
+    }
+    #endif
 }

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -19,6 +19,8 @@ class LuaState {
         void setState(lua_State* state, RefCounted* obj, bool bindAPI);
         void bindLibraries(Array libs);
 
+        void setHook(Callable hook, int mask, int count);
+
         bool luaFunctionExists(String functionName);
 
         lua_State* getState() const;
@@ -48,6 +50,8 @@ class LuaState {
         static int luaPrint(lua_State* state);
         static int luaUserdataFuncCall(lua_State* state);
         static int luaCallableCall(lua_State* state);
+
+        static void luaHook(lua_State* state, lua_Debug* ar);
     private:
         lua_State* L = nullptr;
         RefCounted* obj;


### PR DESCRIPTION
PRs #110 and #112 introduce some issues.

## What they solved
Before there was no way to force a lua coroutine or state to stop executing. Meaning scripts could easily crash the application or etc.

- #110 Added the method `pause_execution` to LuaCoroutine. Which would call `lua_yield` in a hook it sets at the time the function is called. The hook would only run once.
- #112 Added the methods `interrupt_execution` and `kill`. Both of which would create a hook in the same manner as before. `interrupt_execution`  would raise an error one time. Kill would do the same, but never remove its hook.

## The issue
The intent was that the lua state would be executing on a separate thread when these methods were called. However accessing or modifying the lua state on multiple threads is not safe.

## The fix
Instead of having predefined hooks and helper methods as before. This PR adds the ability for the user to create hooks from gdScript. It also adds the ability to yield the lua state from within these hooks. Using `yield_state`. Aswell as retrieving the current running corouitne from the parent LuaAPI object via `get_running_coroutine`.

## Example

```gdscript
extends Node2D

var lua: LuaAPI
var coroutine: LuaCoroutine

func _lua_hook(lua: LuaAPI, event: int, line: int):
	var co: LuaCoroutine = lua.get_running_coroutine()
	co.yield_state([1])

func _ready():
	lua = LuaAPI.new()
	# Despite the name, this is not like a OS coroutine. It is a coroutine.
	coroutine = lua.new_coroutine()
	coroutine.set_hook(_lua_hook, LuaAPI.HOOK_MASK_COUNT, 4)
	coroutine.load_string("
	while true do
		print('Hello world!')
	end
	")

var yieldTime = 0
var timeSince = 0
var goodBye = false
func _process(delta):
	
	timeSince += delta
	# If the coroutine has finished executing or if not enough time has passed, do not resume the coroutine.
	if coroutine.is_done() || timeSince <= yieldTime:
		if !goodBye:
			lua.do_string("""
			for i = 0,10,1 do 
				print('Good Bye World!')
			end
			""")
			goodBye=true
		return
	goodBye=false
	# coroutine.resume will either return a LuaError or an Array.
	var ret = coroutine.resume()
	if ret is LuaError:
		print("ERROR %d: " % ret.type + ret.message)
		return
	# Assumes the user will always pass the number of seconds to pause the coroutine for.
	yieldTime = ret[0]
	timeSince = 0
```
---------
CC @RadiantUwU 
