### PR TITLE
Delete none universal bins

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           lipo -create bin/godot.macos.editor.x86_64.luaAPI bin/godot.macos.editor.arm64.luaAPI -output bin/godot.macos.editor.universal.luaAPI
           strip bin/godot.macos.editor.universal.luaAPI
+          rm -rf bin/godot.macos.editor.x86_64.luaAPI bin/godot.macos.editor.arm64.luaAPI
           mkdir app
           cp -r misc/dist/macos_tools.app app/Godot.app
           mkdir app/Godot.app/Contents/MacOS
@@ -99,6 +100,7 @@ jobs:
         run: |
           lipo -create bin/godot.macos.template_debug.x86_64.luaAPI bin/godot.macos.template_debug.arm64.luaAPI -output bin/godot.macos.template_debug.universal.luaAPI
           lipo -create bin/godot.macos.template_release.x86_64.luaAPI bin/godot.macos.template_release.arm64.luaAPI -output bin/godot.macos.template_release.universal.luaAPI
+          rm -rf bin/godot.macos.template_debug.x86_64.luaAPI bin/godot.macos.template_debug.arm64.luaAPI bin/godot.macos.template_release.x86_64.luaAPI bin/godot.macos.template_release.arm64.luaAPI
           strip bin/godot.*
           mkdir app
           cp -r misc/dist/macos_template.app app/macos_template.app


### PR DESCRIPTION
Resolves #97 
Currently macOS keeps x86_64 and arm64 bins along with the universal ones. This resolves that.