### PR TITLE
Fix lua_hook pushing a nil value if hook returns nothing

### DIFF
--- a/.github/workflows/gdextension-unit-tests.yml
+++ b/.github/workflows/gdextension-unit-tests.yml
@@ -13,9 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download godot 4.0.3
-        uses: wei/wget@v1
-        with:
-          args: -O godot.zip https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
+        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
       - name: Extract godot
         run: |
           7z x godot.zip
@@ -45,9 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download godot 4.0.3
-        uses: wei/wget@v1
-        with:
-          args: -O godot.zip https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
+        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/4.0.3/Godot_v4.0.3-stable_linux.x86_64.zip
       - name: Extract godot
         run: |
           7z x godot.zip

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ About
 ![Logo](.github/LuaAPI.png)
 Art created by [Alex](https://www.instagram.com/redheadalex1)
 
-***WARNING!!!*** this is a **beta** version of the addon made for Godot v4.0-stable. Which means frequent recompiles may be required and compatibility is not guaranteed between updates. Please see the branch [v1.1-stable](https://github.com/WeaselGames/godot_luaAPI/tree/v1.1-stable) for godot v3.x.
+***WARNING!!!*** this is a **beta** version of the addon made for Godot v4.0-stable. Which means frequent recompiles may be required and compatibility is not guaranteed between updates.
 
-This is a Godot addon that adds Lua API support via GDScript. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This addon provides no functionality to program your game out of the box. This addon allows you to create custom Modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
+This is a Godot addon that adds Lua API support via GDScript, C# or GDExtension. Importantly this is **NOT** meant to be a replacement for or alternative to GDScript. This addon provides no functionality to program your game out of the box. This addon allows you to create custom Modding API's in a sandboxed environment. You have control of what people can and can not do within that sandbox.
 
 To use you can either [Compile from source](#compiling) or you can download one of the [nightly builds](#nightly-builds).
 

--- a/scripts/codespell.sh
+++ b/scripts/codespell.sh
@@ -3,4 +3,4 @@ SKIP_LIST="./external,./.git,*.desktop,*.gen.*,*.po,*.pot,*.rc"
 
 IGNORE_LIST="curvelinear,doubleclick,expct,findn,gird,hel,inout,lod,nd,numer,ot,te,vai"
 
-codespell -w -q 3 -S "${SKIP_LIST}" -L "${IGNORE_LIST}" --builtin "clear,rare,en-GB_to_en-US"git status
+codespell -w -q 3 -S "${SKIP_LIST}" -L "${IGNORE_LIST}" --builtin "clear,rare,en-GB_to_en-US"

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -896,7 +896,6 @@ void LuaCoroutine::luaHook(lua_State *state, lua_Debug *ar) {
 	const int argc = 3;
 	const Variant *p_args[argc];
 	for (int i = 0; i < argc; i++) {
-		args[i] = LuaState::getVariant(state, i + 1, OBJ);
 		p_args[i] = &args[i];
 	}
 
@@ -907,6 +906,10 @@ void LuaCoroutine::luaHook(lua_State *state, lua_Debug *ar) {
 		LuaError *err = LuaState::handleError(hook.get_method(), error, p_args, argc);
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
+		return;
+	}
+
+	if (returned.get_type() == Variant::NIL) {
 		return;
 	}
 


### PR DESCRIPTION
A couple random bug fixes and a README update

# Bugs Fixed
- Bug with lua hook pushing a nil value onto the state if the Callable returned nothing.
- Bug with module version of the hooks overriding argument values.
- Codespell script had a random command.