### PR TITLE
Start useing buildroot for linux builds

### DIFF
--- a/.github/workflows/gdextension-unit-tests.yml
+++ b/.github/workflows/gdextension-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: extension-test-results
+          name: gdextension-test-results
           path: project/extension-log.txt
     
   gdextension-luajit-unit-tests:
@@ -63,5 +63,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: extension-test-results
+          name: gdextension-luajit-test-results
           path: project/extension-log.txt

--- a/.github/workflows/gdextension.yml
+++ b/.github/workflows/gdextension.yml
@@ -118,11 +118,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: Install gcc-multilib
         if: ${{ startsWith(matrix.arch, 'x86_32') }}
         shell: sh
         run: |
           sudo apt install gcc-multilib g++-multilib
+
       - name: (Windows) Install mingw64
         if: ${{ startsWith(matrix.identifier, 'windows-') }}
         shell: sh
@@ -130,23 +132,34 @@ jobs:
           sudo apt-get install mingw-w64
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
-      - name: (Android) Set up Java 11
-        if: ${{ startsWith(matrix.identifier, 'android-') }}
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-
-      - name: (Android) Set up Android SDK
-        if: ${{ startsWith(matrix.identifier, 'android-') }}
-        uses: android-actions/setup-android@v2
-
-      - name: (Android) Install Android Tools
-        if: ${{ startsWith(matrix.identifier, 'android-') }}
+      
+      - name: (Linux) Install buildroot x86_64
+        if: ${{ startsWith(matrix.identifier, 'linux-') && contains(matrix.arch, 'x86_64')}}
         shell: sh
         run: |
-          "$ANDROID_SDK_ROOT"/cmdline-tools/latest/bin/sdkmanager --sdk_root="$ANDROID_SDK_ROOT" "platform-tools" "build-tools;30.0.3" "platforms;android-29" "cmdline-tools;latest" "cmake;3.10.2.4988404" "ndk;21.4.7075529"
-      - name: Set up Python
-        uses: actions/setup-python@v2
+          sudo apt-get update
+          sudo apt-get install yasm
+          cd /opt
+          curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          mv x86_64-godot-linux-gnu_sdk-buildroot buildroot
+          cd buildroot
+          ./relocate-sdk.sh
+      
+      - name: (Linux) Install buildroot x86_32
+        if: ${{ startsWith(matrix.identifier, 'linux-') && contains(matrix.arch, 'x86_32')}}
+        shell: sh
+        run: |
+          sudo apt-get update
+          sudo apt-get install yasm
+          cd /opt
+          curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/i686-godot-linux-gnu_sdk-buildroot.tar.bz2
+          tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2
+          rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2
+          mv i686-godot-linux-gnu_sdk-buildroot buildroot
+          cd buildroot
+          ./relocate-sdk.sh
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -170,7 +183,7 @@ jobs:
       - name: Compile extension
         shell: sh
         run: |
-          scons target='${{ matrix.target }}' platform='${{ matrix.platform }}' arch='${{ matrix.arch }}' -j2
+          scons target='${{ matrix.target }}' platform='${{ matrix.platform }}' arch='${{ matrix.arch }}' ${{ matrix.args }}
           ls -l project/addons/luaAPI/bin/
       - name: Strip bins
         if: "!startsWith(matrix.identifier, 'windows-') && startsWith(matrix.arch, 'x86_')"
@@ -270,11 +283,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
+
       - name: Install gcc-multilib
         if: ${{ startsWith(matrix.arch, 'x86_32') }}
         shell: sh
         run: |
           sudo apt install gcc-multilib g++-multilib
+
       - name: (Windows) Install mingw64
         if: ${{ startsWith(matrix.identifier, 'windows-') }}
         shell: sh
@@ -282,9 +297,34 @@ jobs:
           sudo apt-get install mingw-w64
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
-
-      - name: Set up Python
-        uses: actions/setup-python@v2
+      
+      - name: (Linux) Install buildroot x86_64
+        if: ${{ startsWith(matrix.identifier, 'linux-') && contains(matrix.arch, 'x86_64')}}
+        shell: sh
+        run: |
+          sudo apt-get update
+          sudo apt-get install yasm
+          cd /opt
+          curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          mv x86_64-godot-linux-gnu_sdk-buildroot buildroot
+          cd buildroot
+          ./relocate-sdk.sh
+      
+      - name: (Linux) Install buildroot x86_32
+        if: ${{ startsWith(matrix.identifier, 'linux-') && contains(matrix.arch, 'x86_32')}}
+        shell: sh
+        run: |
+          sudo apt-get update
+          sudo apt-get install yasm
+          cd /opt
+          curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/i686-godot-linux-gnu_sdk-buildroot.tar.bz2
+          tar xf i686-godot-linux-gnu_sdk-buildroot.tar.bz2
+          rm -f i686-godot-linux-gnu_sdk-buildroot.tar.bz2
+          mv i686-godot-linux-gnu_sdk-buildroot buildroot
+          cd buildroot
+          ./relocate-sdk.sh
 
       - name: Set up Python
         uses: actions/setup-python@v2
@@ -305,11 +345,18 @@ jobs:
             ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
             ${{github.job}}-${{env.BASE_BRANCH}}-${{github.ref}}
             ${{github.job}}-${{env.BASE_BRANCH}}-${{env.BASE_BRANCH}}
-      - name: Compile extension
+      - name: Compile extension (Other)
+        if: "!startsWith(matrix.identifier, 'linux-')"
         shell: sh
         run: |
-          scons target='${{ matrix.target }}' platform='${{ matrix.platform }}' arch='${{ matrix.arch }}' luaappi_luaver=jit -j2
-          ls -l project/addons/luaAPI/bin/
+         scons target='${{ matrix.target }}' platform='${{ matrix.platform }}' arch='${{ matrix.arch }}' luaappi_luaver=jit -j2
+         ls -l project/addons/luaAPI/bin/
+      - name: Compile extension (Linux)
+        if: "startsWith(matrix.identifier, 'linux-')"
+        shell: sh
+        run: |
+         PATH=/opt/buildroot/bin:$PATH scons target='${{ matrix.target }}' platform='${{ matrix.platform }}' arch='${{ matrix.arch }}' luaappi_luaver=jit -j2
+         ls -l project/addons/luaAPI/bin/
       - name: Strip bins
         if: "!startsWith(matrix.identifier, 'windows-') && startsWith(matrix.arch, 'x86_')"
         shell: sh

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,8 +40,13 @@ jobs:
       - name: Configure dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
-            libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev libudev-dev libxi-dev libxrandr-dev yasm
+          sudo apt-get install yasm
+          cd /opt
+          curl -LO https://downloads.tuxfamily.org/godotengine/toolchains/linux/2021-02-11/x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          tar xf x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          rm -f x86_64-godot-linux-gnu_sdk-buildroot.tar.bz2
+          cd x86_64-godot-linux-gnu_sdk-buildroot
+          ./relocate-sdk.sh
 
       - name: Load .scons_cache directory
         uses: actions/cache@v2
@@ -71,7 +76,7 @@ jobs:
         env:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
-          scons platform=linuxbsd ${{ matrix.build-options }} ${{ env.SCONSFLAGS }}
+          PATH=/opt/x86_64-godot-linux-gnu_sdk-buildroot/bin:$PATH scons platform=linuxbsd ${{ matrix.build-options }} ${{ env.SCONSFLAGS }}
 
       - name: Prepare artifact
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,17 +16,17 @@ jobs:
       matrix:
         include:
           - name: macOS Editor (target=editor)
-            cache-name: macos-editor-luaapi
+            cache-name: macos-editor
             editor: true
             build-options: "target=editor"
 
           - name: macOS Editor LuaJIT (target=editor, luaapi_luaver=jit)
-            cache-name: macos-editor-luajit-luaapi
+            cache-name: macos-editor-luajit
             editor: true
             build-options: "target=editor luaapi_luaver=jit"
 
           - name: macOS Template
-            cache-name: macos-template-luaapi
+            cache-name: macos-template
             template: true
 
     steps:

--- a/.github/workflows/module-unit-tests.yml
+++ b/.github/workflows/module-unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: test-results
+          name: module-test-results
           path: project/log.txt
 
   module-unit-tests-luajit:
@@ -50,5 +50,5 @@ jobs:
       - uses: actions/upload-artifact@v2
         if: ${{ always() }}
         with:
-          name: module-test-results
+          name: module-luajit-test-results
           path: project/jit-log.txt

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Nightly Builds
 - [🎨 Windows Editor LuaJIT](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/windows-editor-luajit.zip)
 - [🎨 Windows Template](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/windows-template.zip)
 - [🎨 Windows Template Debug](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/windows-template-debug.zip)
-- [🍎 MacOS Editor](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/macos-editor-luaapi.zip)
-- [🍎 MacOS Editor LuaJIT](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/macos-editor-luajit-luaapi.zip)
-- [🍎 MacOS Template](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/macos-template-luaapi.zip)
+- [🍎 MacOS Editor](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/macos-editor.zip)
+- [🍎 MacOS Editor LuaJIT](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/macos-editor-luajit.zip)
+- [🍎 MacOS Template](https://nightly.link/WeaselGames/godot_luaAPI/workflows/runner/main/macos-template.zip)
 
 TODO
 -----

--- a/external/SConscript
+++ b/external/SConscript
@@ -118,5 +118,4 @@ else:
     env.Append(LIBPATH=[Dir("bin").abspath])
     env.Append(LIBS=[library_name])
 
-
 Return('env')


### PR DESCRIPTION
Currently linux builds are built on Ubuntu 20.04, this means its a fairly new glibc version and wont work on many still supported LTS releases of linux. Buildroot forces use of an older glibc version.