### PR TITLE
Improvments to yield_await

### DIFF
--- a/doc_classes/LuaCoroutine.xml
+++ b/doc_classes/LuaCoroutine.xml
@@ -46,8 +46,9 @@
 		</method>
 		<method name="resume">
 			<return type="Variant" />
+			<param index="0" name="Args" type="Array" />
 			<description>
-				Resumes or starts the coroutine. Will either return a Array of arguments passed by lua in yield() or a LuaError.
+				Resumes or starts the coroutine. Will either return a Array of arguments passed by lua in yield() or a LuaError. Arguments are passed to yield() in lua.
 			</description>
 		</method>
 		<method name="is_done">

--- a/project/testing/tests/LuaCoroutine.resume.gd
+++ b/project/testing/tests/LuaCoroutine.resume.gd
@@ -44,7 +44,7 @@ func _process(delta):
 	if timeSince <= yieldTime:
 		return
 
-	var ret = co.resume()
+	var ret = co.resume([])
 	if ret is LuaError:
 		errors.append(ret)
 		return fail()

--- a/project/testing/tests/LuaCoroutine.yield_await.gd
+++ b/project/testing/tests/LuaCoroutine.yield_await.gd
@@ -81,7 +81,7 @@ func _process(delta):
 		done = true
 		return
 
-	var ret = co.resume()
+	var ret = co.resume([])
 	if ret is LuaError:
 		errors.append(ret)
 		return fail()

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -41,7 +41,7 @@ public:
 
 	Ref<LuaAPI> getParent();
 
-	Variant resume();
+	Variant resume(Array args);
 	Variant pullVariant(String name);
 	Variant callFunction(String functionName, Array args);
 

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -34,8 +34,6 @@ public:
 	LuaError *exposeObjectConstructor(String name, Object *obj);
 	LuaError *handleError(int lua_error) const;
 
-	Object *getGDFuncState();
-
 	static LuaError *pushVariant(lua_State *state, Variant var);
 	static LuaError *handleError(lua_State *state, int lua_error);
 #ifndef LAPI_GDEXTENSION
@@ -56,8 +54,6 @@ public:
 private:
 	lua_State *L = nullptr;
 	RefCounted *obj = nullptr;
-
-	static VMap<lua_State *, Object *> GDFunctionStates;
 
 	void exposeConstructors();
 	void createVector2Metatable();


### PR DESCRIPTION
Previously we stored a reference to the GDScript function state in order to resume later, this PR utilizes the signal await binds to instead and cleans up after.

LuaCoroutine.resume now also takes an array of arguments that can be passed to yield() in lua