### PR TITLE
Add permissive mode

### DIFF
--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -89,6 +89,11 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="permissive" type="bool" setter="set_permissive" getter="get_permissive" default="false">
+			Set weather an objects lua_fields method should be treated as a blacklist instead of a whitelist.
+		</member>
+	</members>
 	<constants>
 		<constant name="HOOK_MASK_CALL" value="1" enum="HookMask">
 			Specifies on which events the hook will be called.

--- a/project/demo/HelloLua.gd
+++ b/project/demo/HelloLua.gd
@@ -7,11 +7,11 @@ func _lua_print(message: String):
 	return LuaError.new_error("test", LuaError.ERR_RUNTIME)
 
 func _ready():
+	# All builtin libraries are available to bind with. Use Debug, OS and IO at your own risk.
+	lua.bind_libraries(["base", "table", "string"])
+
 	lua.push_variant("print", _lua_print)
 	lua.push_variant("message", "Hello lua!")
-
-	# All builtin libraries are available to bind with. Use OS and IO at your own risk.
-	lua.bind_libraries(["base", "table", "string"])
 
 	# Most methods return a LuaError in case of an error
 	var err: LuaError = lua.do_string("""

--- a/project/testing/tests/LuaAPI.call_function.gd
+++ b/project/testing/tests/LuaAPI.call_function.gd
@@ -8,6 +8,7 @@ func _ready():
 	id = 9970
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 
 	# testName and testDescription are for any needed context about the test.
 	testName = "LuaAPI.call_function"

--- a/project/testing/tests/LuaAPI.expose_constructor.gd
+++ b/project/testing/tests/LuaAPI.expose_constructor.gd
@@ -12,6 +12,7 @@ func _ready():
 	id = 9950
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 	var err = lua.expose_constructor("TestObj", TestObject)
 	if err is LuaError:
 		errors.append(err)

--- a/project/testing/tests/LuaAPI.expose_function.gd
+++ b/project/testing/tests/LuaAPI.expose_function.gd
@@ -40,6 +40,7 @@ func _ready():
 	id = 9940
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 	lua.set_meta("isValid", true)
 	var err = lua.push_variant("test1", LuaCallableExtra.with_tuple(testFuncTuple, 2))
 	if err is LuaError:

--- a/project/testing/tests/LuaCoroutine.resume.gd
+++ b/project/testing/tests/LuaCoroutine.resume.gd
@@ -9,6 +9,7 @@ func _ready():
 	id = 9500
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 	co = lua.new_coroutine()
 
 	co.load_string("

--- a/project/testing/tests/LuaCoroutine.yield_await.gd
+++ b/project/testing/tests/LuaCoroutine.yield_await.gd
@@ -13,6 +13,7 @@ func _ready():
 	id = 9490
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 	co = lua.new_coroutine()
 	co.push_variant("test_yield_await", _test_yield_await)
 

--- a/project/testing/tests/general.base_types.gd
+++ b/project/testing/tests/general.base_types.gd
@@ -8,6 +8,7 @@ func _ready():
 	id = 9825
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 
 	# testName and testDescription are for any needed context about the test.
 	testName = "General.base_types"

--- a/project/testing/tests/general.object_metamethods.gd
+++ b/project/testing/tests/general.object_metamethods.gd
@@ -16,6 +16,7 @@ func _ready():
 	id = 9850
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 	lua.set_meta("isValid", true)
 	testObj = TestObject.new()
 	lua.push_variant("testObj", testObj)

--- a/project/testing/tests/general.object_push.gd
+++ b/project/testing/tests/general.object_push.gd
@@ -14,6 +14,7 @@ func _ready():
 
 	testObj = TestObject.new()
 	lua = LuaAPI.new()
+	lua.permissive = true
 	var err = lua.push_variant("testObj", testObj)
 	if err is LuaError:
 		errors.append(err)

--- a/project/testing/tests/luaAPI.do_file.gd
+++ b/project/testing/tests/luaAPI.do_file.gd
@@ -8,6 +8,7 @@ func _ready():
 	id = 9990
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 
 	# testName and testDescription are for any needed context about the test.
 	testName = "LuaAPI.do_file()"

--- a/project/testing/tests/luaAPI.do_string.gd
+++ b/project/testing/tests/luaAPI.do_string.gd
@@ -8,6 +8,7 @@ func _ready():
 	id = 10000
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 
 	# testName and testDescription are for any needed context about the test.
 	testName = "LuaAPI.do_string()"

--- a/project/testing/tests/luaAPI.pull_variant.gd
+++ b/project/testing/tests/luaAPI.pull_variant.gd
@@ -8,6 +8,7 @@ func _ready():
 	id = 9980
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 
 	# testName and testDescription are for any needed context about the test.
 	testName = "LuaAPI.pull_variant()"

--- a/project/testing/tests/luaAPI.push_variant.gd
+++ b/project/testing/tests/luaAPI.push_variant.gd
@@ -8,6 +8,7 @@ func _ready():
 	id = 9960
 
 	lua = LuaAPI.new()
+	lua.permissive = true
 
 	# testName and testDescription are for any needed context about the test.
 	testName = "LuaAPI.push_variant()"

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -37,6 +37,11 @@ void LuaAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("new_coroutine"), &LuaAPI::newCoroutine);
 	ClassDB::bind_method(D_METHOD("get_running_coroutine"), &LuaAPI::getRunningCoroutine);
 
+	ClassDB::bind_method(D_METHOD("set_permissive", "value"), &LuaAPI::setPermissive);
+	ClassDB::bind_method(D_METHOD("get_permissive"), &LuaAPI::getPermissive);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "permissive"), "set_permissive", "get_permissive");
+
 	BIND_ENUM_CONSTANT(HOOK_MASK_CALL);
 	BIND_ENUM_CONSTANT(HOOK_MASK_RETURN);
 	BIND_ENUM_CONSTANT(HOOK_MASK_LINE);

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -35,6 +35,14 @@ public:
 	void bindLibraries(Array libs);
 	void setHook(Callable hook, int mask, int count);
 
+	inline void setPermissive(bool permissive) {
+		this->permissive = permissive;
+	}
+
+	inline bool getPermissive() const {
+		return permissive;
+	}
+
 	bool luaFunctionExists(String functionName);
 
 	Variant pullVariant(String name);
@@ -68,7 +76,9 @@ public:
 
 private:
 	LuaState state;
-	lua_State *lState;
+	lua_State *lState = nullptr;
+
+	bool permissive = false;
 
 	// Temp. Looking for better method. Maybe?
 	Array refs;

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -18,7 +18,6 @@ class LuaState {
 public:
 	void setState(lua_State *state, RefCounted *obj, bool bindAPI);
 	void bindLibraries(Array libs);
-
 	void setHook(Callable hook, int mask, int count);
 
 	bool luaFunctionExists(String functionName);


### PR DESCRIPTION
Currently if a object does not define an `__index` or a `lua_fields` method all fields/methods will be allowed. And if it does its treated as a whitelist.

This PR makes it so if its not defined by default no fields/methods will be allowed. And adds a permissive mode which when enabled will allow all fields/methods by default and treat lua_fields as a blacklist instead.

`__newindex` and `__index` still take priority over all though. 