### PR TITLE
Use memmove instead of memcpy

### DIFF
--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -88,6 +88,13 @@
 				Sets the hook for the state. The hook will be called on the events specified by the mask. The count specifies how many instructions should be executed before the hook is called. If count is 0, the hook will be called on every instruction. The hook will be called with the following arguments: [code]hook(parent, event, line)[/code]. The parent is the LuaAPI object that owns the current state.
 			</description>
 		</method>
+		<method name="configure_gc">
+			<return type="int" />
+			<param index="0" name="option" type="int" />
+			<param index="1" name="data" type="int" />
+			<description>
+				Controls the garbage collector. The option can be one of the following: [code]GC_STOP[/code], [code]GC_RESTART[/code], [code]GC_COLLECT[/code], [code]GC_COUNT[/code], [code]GC_STEP[/code], [code]GC_SETPAUSE[/code], [code]GC_SETSTEPMUL[/code]. The data is the argument for the option. Returns the result of the option.
+			</description>
 	</methods>
 	<members>
 		<member name="permissive" type="bool" setter="set_permissive" getter="get_permissive" default="false">
@@ -95,7 +102,7 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="HOOK_MASK_CALL" value="1" enum="HookMask">
+		<constant name="GC_STOP" value="1" enum="HookMask">
 			Specifies on which events the hook will be called.
 		</constant>
 		<constant name="HOOK_MASK_RETURN" value="2" enum="HookMask">
@@ -106,6 +113,31 @@
 		</constant>
 		<constant name="HOOK_MASK_COUNT" value="8" enum="HookMask">
 			Specifies on which events the hook will be called.
+		</constant>
+
+		<constant name="GC_STOP" value="0" enum="GCOption">
+			Stops the garbage collector.
+		</constant>
+		<constant name="GC_RESTART" value="1" enum="GCOption">
+			Restarts the garbage collector.
+		</constant>
+		<constant name="GC_COLLECT" value="2" enum="GCOption">
+			Performs a full garbage-collection cycle.
+		</constant>
+		<constant name="GC_COUNT" value="3" enum="GCOption">
+			Returns the current amount of memory (in Kbytes) in use by Lua.
+		</constant>
+		<constant name="GC_COUNTB" value="4" enum="GCOption">
+			Returns the remainder of dividing the current amount of bytes of memory in use by Lua by 1024.
+		</constant>
+		<constant name="GC_STEP" value="5" enum="GCOption">
+			Performs an incremental step of garbage collection.
+		</constant>
+		<constant name="GC_SETPAUSE" value="6" enum="GCOption">
+			Sets [code]data[/code] as the new value for the pause of the collector.
+		</constant>
+		<constant name="GC_SETSTEPMUL" value="7" enum="GCOption">
+			Sets [code]data[/code] as the new value for the step multiplier of the collector.
 		</constant>
 	</constants>
 </class>

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -13,11 +13,6 @@ LuaAPI::LuaAPI() {
 }
 
 LuaAPI::~LuaAPI() {
-	for (auto &[key, val] : ownedObjects) {
-		if (val != nullptr) {
-			memdelete(val);
-		}
-	}
 	lua_close(lState);
 }
 

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -13,9 +13,6 @@
 #include <luaState.h>
 #include <lua/lua.hpp>
 
-#include <map>
-#include <string>
-
 #ifdef LAPI_GDEXTENSION
 using namespace godot;
 #endif
@@ -34,6 +31,10 @@ public:
 
 	void bindLibraries(Array libs);
 	void setHook(Callable hook, int mask, int count);
+
+	inline int confgiure_gc(int what, int data) {
+		return lua_gc(lState, what, data);
+	}
 
 	inline void setPermissive(bool permissive) {
 		this->permissive = permissive;
@@ -59,14 +60,6 @@ public:
 	lua_State *newThreadState();
 	lua_State *getState();
 
-	inline void addRef(Variant var) {
-		refs.append(var);
-	}
-
-	inline void addOwnedObject(void *luaPtr, Variant *obj) {
-		ownedObjects[luaPtr] = obj;
-	}
-
 	enum HookMask {
 		HOOK_MASK_CALL = LUA_MASKCALL,
 		HOOK_MASK_RETURN = LUA_MASKRET,
@@ -74,15 +67,22 @@ public:
 		HOOK_MASK_COUNT = LUA_MASKCOUNT,
 	};
 
+	enum GCOption {
+		GC_STOP = LUA_GCSTOP,
+		GC_RESTART = LUA_GCRESTART,
+		GC_COLLECT = LUA_GCCOLLECT,
+		GC_COUNT = LUA_GCCOUNT,
+		GC_COUNTB = LUA_GCCOUNTB,
+		GC_STEP = LUA_GCSTEP,
+		GC_SETPAUSE = LUA_GCSETPAUSE,
+		GC_SETSTEPMUL = LUA_GCSETSTEPMUL,
+	};
+
 private:
 	LuaState state;
 	lua_State *lState = nullptr;
 
 	bool permissive = false;
-
-	// Temp. Looking for better method. Maybe?
-	Array refs;
-	std::map<void *, Variant *> ownedObjects;
 
 	LuaError *execute(int handlerIndex);
 };


### PR DESCRIPTION
This PR fixes some pretty bad memory leaks. Somewhere along the line a bad assumption was made that memcpy had to be used instead of just storing the value. While just storing the value does work for module builds, because of how GDExtension works it cant really handle a null Variant. This is because all variants even null ones point to a Variant in the engine its self. Thus when we assign a real value to a null variant it causes a memory exception. For this reason memmove was used instead. As a safe way to transfer the value to lua. The ref count is also incremented for RefCounted's when passed to lua. And de incremented in the lua gc.

The configure_gc method has also been added. It is a direct exposure of [lua_gc](https://www.lua.org/manual/5.4/manual.html#lua_gc) from the C API.