### PR TITLE
Fix some regression issues

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -11,6 +11,7 @@ on:
       - "**/LICENSE"
       - ".github/ISSUE_TEMPLATE/*"
       - ".github/CODEOWNERS"
+      - "project/demo/*"
   push:
     branches:
       - "main"
@@ -20,6 +21,7 @@ on:
       - "**/LICENSE"
       - ".github/ISSUE_TEMPLATE/*"
       - ".github/CODEOWNERS"
+      - "project/demo/*"
 
 env:
   GODOT_VERSION: ${{ vars.GODOT_VERSION }}

--- a/project/demo/HelloLua.gd
+++ b/project/demo/HelloLua.gd
@@ -4,7 +4,6 @@ var lua: LuaAPI = LuaAPI.new()
 
 func _lua_print(message: String):
 	print(message)
-	return LuaError.new_error("test", LuaError.ERR_RUNTIME)
 
 func _ready():
 	# All builtin libraries are available to bind with. Use Debug, OS and IO at your own risk.
@@ -22,7 +21,12 @@ func _ready():
 		return "Hello gdScript!"
 	end
 	""")
-
 	if err is LuaError:
 		print("ERROR %d: %s" % [err.type, err.message])
 		return
+	
+	var ret = lua.call_function("get_message", [])
+	if ret is LuaError:
+		print("ERROR %d: %s" % [err.type, err.message])
+		return
+	print(ret)

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -23,6 +23,7 @@ void LuaAPI::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("bind_libraries", "Array"), &LuaAPI::bindLibraries);
 	ClassDB::bind_method(D_METHOD("set_hook", "Hook", "HookMask", "Count"), &LuaAPI::setHook);
+	ClassDB::bind_method(D_METHOD("configure_gc", "What", "Data"), &LuaAPI::configure_gc);
 	ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
 	ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
 	ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
@@ -41,6 +42,15 @@ void LuaAPI::_bind_methods() {
 	BIND_ENUM_CONSTANT(HOOK_MASK_RETURN);
 	BIND_ENUM_CONSTANT(HOOK_MASK_LINE);
 	BIND_ENUM_CONSTANT(HOOK_MASK_COUNT);
+
+	BIND_ENUM_CONSTANT(GC_STOP);
+	BIND_ENUM_CONSTANT(GC_RESTART);
+	BIND_ENUM_CONSTANT(GC_COLLECT);
+	BIND_ENUM_CONSTANT(GC_COUNT);
+	BIND_ENUM_CONSTANT(GC_COUNTB);
+	BIND_ENUM_CONSTANT(GC_STEP);
+	BIND_ENUM_CONSTANT(GC_SETPAUSE);
+	BIND_ENUM_CONSTANT(GC_SETSTEPMUL);
 }
 
 // Calls LuaState::bindLibs()

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -32,12 +32,12 @@ public:
 	void bindLibraries(Array libs);
 	void setHook(Callable hook, int mask, int count);
 
-	inline int confgiure_gc(int what, int data) {
+	inline int configure_gc(int what, int data) {
 		return lua_gc(lState, what, data);
 	}
 
-	inline void setPermissive(bool permissive) {
-		this->permissive = permissive;
+	inline void setPermissive(bool value) {
+		permissive = value;
 	}
 
 	inline bool getPermissive() const {
@@ -88,5 +88,6 @@ private:
 };
 
 VARIANT_ENUM_CAST(LuaAPI::HookMask)
+VARIANT_ENUM_CAST(LuaAPI::GCOption)
 
 #endif


### PR DESCRIPTION
The previous set of changes caused some regression due to the differences of how GDExtension and Modules work. memove is needed for GDExtension because all Variants for it are pointers to Variants living in the engine, assigning to a null Variant allocated by lua will cause a null pointer deref. Therefore we skip the assignment operator by using memmove. We need to do some manually ref counting to make this work.

For modules memmove caused a lot more issues so this PR has the Module version use the assignment operator. 

The other major change was we now test if a Callable is custom and send it as a blank LuaCallableExtra instead. We do this to create a wrapper to the callable custom which will always have a RefCounted. Without this we have no way to manually increment the ref counter so it gets cleaned up.

There was also some steps missing to fully expose the GC options which have been fixed.