### PR TITLE
pushVariant: Save key array for loop

### DIFF
--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -271,8 +271,9 @@ LuaError *LuaState::pushVariant(lua_State *state, Variant var) {
 			Dictionary dict = var.operator Dictionary();
 			lua_createtable(state, 0, dict.size());
 
+			Array keys = dict.keys();
 			for (int i = 0; i < dict.size(); i++) {
-				Variant key = dict.keys()[i];
+				Variant key = keys[i];
 				Variant value = dict[key];
 
 				LuaError *err = pushVariant(state, key);


### PR DESCRIPTION
tiny edit to avoid squared key lookup times when pushing variant dictionaries