### PR TITLE
Fixed crashes with pushVariant

### DIFF
--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -520,16 +520,6 @@ void LuaState::createObjectMetatable() {
 		return 1;
 	});
 
-#ifndef LAPI_GDEXTENSION
-	LUA_METAMETHOD_TEMPLATE(L, -1, "__gc", {
-		if (!arg1.has_method("__gc")) {
-			return 0;
-		}
-
-		LuaState::pushVariant(inner_state, arg1.call("__gc", api));
-		return 1;
-	});
-#else
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__gc", {
 		// If object is a RefCounted
 		Ref<RefCounted> ref = Object::cast_to<RefCounted>(arg1);
@@ -544,7 +534,6 @@ void LuaState::createObjectMetatable() {
 		LuaState::pushVariant(inner_state, arg1.call("__gc", api));
 		return 1;
 	});
-#endif
 
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__tostring", {
 		// If object overrides
@@ -774,7 +763,6 @@ void LuaState::createCallableMetatable() {
 void LuaState::createCallableExtraMetatable() {
 	luaL_newmetatable(L, "mt_CallableExtra");
 
-#ifdef LAPI_GDEXTENSION
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__gc", {
 		Ref<RefCounted> ref = Object::cast_to<RefCounted>(arg1);
 		if (ref != nullptr) {
@@ -783,7 +771,6 @@ void LuaState::createCallableExtraMetatable() {
 
 		return 0;
 	});
-#endif
 
 	lua_pushstring(L, "__call");
 	lua_pushcfunction(L, LuaCallableExtra::call);


### PR DESCRIPTION
This fixed some crashes that were reported in discord. There was 2 separate issues. One which effected module builds and one which effected GDExtension builds.

### For the module builds:
~The issue was with the fact that we create Variant pointers with `lua_newuserdata`. The can cause issues because of the way Variants work, for primitives it will store the literal value. Object and RefCounted types are pointers. The issue we were having is Variant has an assignment operator that calls clear() for primitives this sets the 0 value, for objects and refcounted types it calls their clear() method. Its a switch case for the type. Objects go to default. However since our initial Variant was allocated by lua its dirty memory so it has an invalid type that it tries to use to lookup its clear method. But since its invalid it dose not exist~

The issue is we need to also manually refCount for objects like we did for GDExtension

### For GDExtension builds:
The issue had to do with a long know issue to do with `Object::cast_to` that should of bee caught earlier.

CC @vitawrap 