### PR TITLE
Bump godot version to 4.1

### DIFF
--- a/.github/workflows/gdextension-unit-tests.yml
+++ b/.github/workflows/gdextension-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download godot ${{ inputs.godot_version }}
-        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/Godot_v${{ inputs.godot_version }}-rc2_linux.x86_64.zip
+        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/rc2/Godot_v${{ inputs.godot_version }}-rc2_linux.x86_64.zip
       - name: Extract godot
         run: |
           7z x godot.zip
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download godot ${{ inputs.godot_version }}
-        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/Godot_v${{ inputs.godot_version }}-rc2_linux.x86_64.zip
+        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/rc2/Godot_v${{ inputs.godot_version }}-rc2_linux.x86_64.zip
       - name: Extract godot
         run: |
           7z x godot.zip

--- a/.github/workflows/gdextension-unit-tests.yml
+++ b/.github/workflows/gdextension-unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download godot ${{ inputs.godot_version }}
-        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/Godot_v${{ inputs.godot_version }}-stable_linux.x86_64.zip
+        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/Godot_v${{ inputs.godot_version }}-rc2_linux.x86_64.zip
       - name: Extract godot
         run: |
           7z x godot.zip
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download godot ${{ inputs.godot_version }}
-        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/Godot_v${{ inputs.godot_version }}-stable_linux.x86_64.zip
+        run: wget -O godot.zip https://downloads.tuxfamily.org/godotengine/${{ inputs.godot_version }}/Godot_v${{ inputs.godot_version }}-rc2_linux.x86_64.zip
       - name: Extract godot
         run: |
           7z x godot.zip

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -24,7 +24,7 @@ on:
       - "project/demo/*"
 
 env:
-  GODOT_VERSION: 4.0.3
+  GODOT_VERSION: 4.1
 
 jobs:
   static-checks:
@@ -37,7 +37,7 @@ jobs:
     uses: ./.github/workflows/linux.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
 
   macos-build:
     name: 🍎 macOS
@@ -45,7 +45,7 @@ jobs:
     uses: ./.github/workflows/macos-build.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
   
   macos-package:
     name: 🍎 macOS Package
@@ -60,7 +60,7 @@ jobs:
     uses: ./.github/workflows/android-build.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
   
   android-package:
     name: 🤖 Android Package
@@ -74,7 +74,7 @@ jobs:
     uses: ./.github/workflows/ios-build.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
   
   ios-package:
     name: 🍎 IOS Package
@@ -88,7 +88,7 @@ jobs:
     uses: ./.github/workflows/web.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
 
   windows-build:
     name: 🎨 Windows
@@ -96,7 +96,7 @@ jobs:
     uses: ./.github/workflows/windows.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
   
   gdextension-build:
     name: ⚙️ GDExtension
@@ -104,7 +104,7 @@ jobs:
     uses: ./.github/workflows/gdextension.yml
     with:
       fullbuild: ${{ github.event_name == 'workflow_dispatch' }}
-      godot_version: 4.0.3
+      godot_version: 4.1
   
   module-unit-tests:
     name: ⚙️ Module Unit Tests
@@ -116,7 +116,7 @@ jobs:
     needs: gdextension-build
     uses: ./.github/workflows/gdextension-unit-tests.yml
     with:
-      godot_version: 4.0.3
+      godot_version: 4.1
 
   template-version-file:
     name: 📝 Create template version file
@@ -126,7 +126,7 @@ jobs:
       - name: Create version file
         run: |
           mkdir -p ${{ github.workspace }}/bin/templates
-          echo ${{ env.GODOT_VERSION }}.stable > ${{ github.workspace }}/bin/templates/version.txt
+          echo ${{ env.GODOT_VERSION }}.rc2 > ${{ github.workspace }}/bin/templates/version.txt
       - name: Upload version file
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -6,9 +6,9 @@ on:
     branches:
       - "*"
     paths-ignore:
-      - "**/README.md"
+      - "README.md"
+      - "LICENSE"
       - "**/*.png"
-      - "**/LICENSE"
       - ".github/ISSUE_TEMPLATE/*"
       - ".github/CODEOWNERS"
       - "project/demo/*"

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Release Builds
 
 Compiling
 ------------
-This build is for godot 4.0-stable.
-- Start by cloning the Godot 4.0-stable [source](https://github.com/godotengine/godot) with this command `git clone -b 4.0 https://github.com/godotengine/godot`
+This build is for godot 4.1.
+- Start by cloning the Godot 4.1 [source](https://github.com/godotengine/godot) with this command `git clone https://github.com/godotengine/godot`
 - Next change directories into the modules folder and clone this repo into a folder named luaAPI with this command `git clone --recurse-submodules https://github.com/WeaselGames/godot_luaAPI luaAPI`. Make sure to use --recurse-submodules to pull the submodules as well.
 
 - Now you can follow the Godot build instructions on their [site](https://docs.godotengine.org/en/stable/contributing/development/compiling).

--- a/project/addons/luaAPI/luaAPI.gdextension
+++ b/project/addons/luaAPI/luaAPI.gdextension
@@ -1,5 +1,6 @@
 [configuration]
 entry_symbol = "luaAPI_library_init"
+compatibility_minimum = 4.1
 
 [libraries]
 linux.x86_64.debug = "bin/libluaapi.linux.template_debug.x86_64.so"

--- a/project/project.godot
+++ b/project/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="LuaAPI Test Project"
 run/main_scene="res://testing/run_tests.tscn"
-config/features=PackedStringArray("4.0", "Mobile")
+config/features=PackedStringArray("4.1", "Mobile")
 
 [autoload]
 

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -31,7 +31,7 @@ void uninitialize_luaAPI_module(ModuleInitializationLevel p_level) {
 extern "C" {
 // Initialization.
 
-GDExtensionBool GDE_EXPORT luaAPI_library_init(const GDExtensionInterface *p_interface, const GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
+GDExtensionBool GDE_EXPORT luaAPI_library_init(GDExtensionInterfaceGetProcAddress p_interface, GDExtensionClassLibraryPtr p_library, GDExtensionInitialization *r_initialization) {
 	GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
 
 	init_obj.register_initializer(initialize_luaAPI_module);

--- a/scripts/SConstruct
+++ b/scripts/SConstruct
@@ -11,7 +11,7 @@ import subprocess
 from shutil import copytree, ignore_patterns
 
 # godot v4.0.0-beta10
-godot_ver = os.getenv("GODOT_VERSION", "4.0")
+godot_ver = "master" # os.getenv("GODOT_VERSION", "4.0")
 godot_url = "https://github.com/godotengine/godot"
 godot_dir = Dir("godot")
 

--- a/src/classes/luaCallableExtra.cpp
+++ b/src/classes/luaCallableExtra.cpp
@@ -76,6 +76,7 @@ int LuaCallableExtra::call(lua_State *state) {
 		lua_error(state);
 		return 0;
 	}
+
 	if (func->isTuple) {
 		noneMulty = func->argc - 1; // We subtract one because the tuple is countedA
 	}


### PR DESCRIPTION
Not many changes were needed to make this happen, a couple changes to the GDExtension entry point is all really.