### PR TITLE
getVariant no longer requires api ref

### DIFF
--- a/project/testing/tests/LuaAPI.expose_function.gd
+++ b/project/testing/tests/LuaAPI.expose_function.gd
@@ -85,17 +85,17 @@ func _process(delta):
 
 	var result1 = lua.pull_variant("result1")
 	if not result1:
-		errors.append("result1 is false")
+		errors.append(LuaError.new_error("result1 is false"))
 		fail()
 
 	var result2 = lua.pull_variant("result2")
 	if not result2:
-		errors.append("result2 is false")
+		errors.append(LuaError.new_error("result2 is false"))
 		fail()
 
 	var result3 = lua.pull_variant("result3")
 	if not result3 == 10:
-		errors.append("result3 is not 10 but is %d" % result3)
+		errors.append(LuaError.new_error("result3 is not 10 but is %d" % result3))
 		fail()
 
 	done = true

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -15,10 +15,10 @@ void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 	}
 
 	ClassDB::register_class<LuaAPI>();
+	ClassDB::register_class<LuaCallableExtra>();
 	ClassDB::register_class<LuaCoroutine>();
 	ClassDB::register_class<LuaError>();
 	ClassDB::register_class<LuaTuple>();
-	ClassDB::register_class<LuaCallableExtra>();
 }
 
 void uninitialize_luaAPI_module(ModuleInitializationLevel p_level) {

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -98,7 +98,7 @@ Variant LuaAPI::callFunctionRef(Array args, int funcRef) {
 	if (ret != LUA_OK) {
 		toReturn = LuaState::handleError(lState, ret);
 	} else {
-		toReturn = LuaState::getVariant(lState, -1, this);
+		toReturn = LuaState::getVariant(lState, -1);
 	}
 
 	lua_pop(lState, 1);

--- a/src/classes/luaCallableExtra.cpp
+++ b/src/classes/luaCallableExtra.cpp
@@ -65,11 +65,9 @@ int LuaCallableExtra::getArgc() {
 
 // Used for the __call metamethod
 int LuaCallableExtra::call(lua_State *state) {
-	LuaAPI *api = LuaState::getAPI(state);
-
 	int l_argc = lua_gettop(state) - 1; // We subtract 1 because the LuaCallableExtra is counted
 	int noneMulty = l_argc;
-	LuaCallableExtra *func = (LuaCallableExtra *)LuaState::getVariant(state, 1, api).operator Object *();
+	LuaCallableExtra *func = (LuaCallableExtra *)LuaState::getVariant(state, 1).operator Object *();
 	if (func == nullptr) {
 		LuaError *err = LuaError::newError("Error during LuaCallableExtra::call func==null", LuaError::ERR_RUNTIME);
 		lua_pushstring(state, err->getMessage().ascii().get_data());
@@ -84,18 +82,18 @@ int LuaCallableExtra::call(lua_State *state) {
 	Array args;
 
 	if (func->wantsRef) {
-		args.append(api);
+		args.append(Ref<LuaAPI>(LuaState::getAPI(state)));
 	}
 
 	int index = 2; // we start at 2 because the LuaCallableExtra is arg 1
 	for (int i = 0; i < noneMulty; i++) {
-		args.append(LuaState::getVariant(state, index++, api));
+		args.append(LuaState::getVariant(state, index++));
 	}
 
 	if (func->isTuple) {
 		Array tupleArgs;
 		for (int i = noneMulty; i < l_argc; i++) {
-			tupleArgs.push_back(LuaState::getVariant(state, index++, api));
+			tupleArgs.push_back(LuaState::getVariant(state, index++));
 		}
 		args.append(LuaTuple::fromArray(tupleArgs));
 	}

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -43,7 +43,7 @@ public:
 #else
 	static LuaError *handleError(const StringName &func, GDExtensionCallError error, const Variant **p_arguments, int argc);
 #endif
-	static Variant getVariant(lua_State *state, int index, LuaAPI *api);
+	static Variant getVariant(lua_State *state, int index);
 
 	// Lua functions
 	static int luaErrorHandler(lua_State *state);
@@ -54,8 +54,6 @@ public:
 	static void luaHook(lua_State *state, lua_Debug *ar);
 
 private:
-	LuaAPI *api = nullptr;
-
 	lua_State *L = nullptr;
 
 	void exposeConstructors();

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -7,15 +7,14 @@
 // These 2 macros helps us in constructing general metamethods.
 // We can use "lua" as a "Lua" pointer and arg1, arg2, ..., arg5 as Variants objects
 // Check examples in createVector2Metatable
-#define LUA_LAMBDA_TEMPLATE(_f_)                                  \
-	[](lua_State *inner_state) -> int {                           \
-		LuaAPI *api = LuaState::getAPI(inner_state);              \
-		Variant arg1 = LuaState::getVariant(inner_state, 1, api); \
-		Variant arg2 = LuaState::getVariant(inner_state, 2, api); \
-		Variant arg3 = LuaState::getVariant(inner_state, 3, api); \
-		Variant arg4 = LuaState::getVariant(inner_state, 4, api); \
-		Variant arg5 = LuaState::getVariant(inner_state, 5, api); \
-		_f_                                                       \
+#define LUA_LAMBDA_TEMPLATE(_f_)                             \
+	[](lua_State *inner_state) -> int {                      \
+		Variant arg1 = LuaState::getVariant(inner_state, 1); \
+		Variant arg2 = LuaState::getVariant(inner_state, 2); \
+		Variant arg3 = LuaState::getVariant(inner_state, 3); \
+		Variant arg4 = LuaState::getVariant(inner_state, 4); \
+		Variant arg5 = LuaState::getVariant(inner_state, 5); \
+		_f_                                                  \
 	}
 
 #define LUA_METAMETHOD_TEMPLATE(lua_state, metatable_index, metamethod_name, _f_) \
@@ -412,6 +411,8 @@ void LuaState::createObjectMetatable() {
 	luaL_newmetatable(L, "mt_Object");
 
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__index", {
+		Ref<LuaAPI> api = getAPI(inner_state);
+
 		// If object overrides
 		if (arg1.has_method("__index")) {
 			LuaState::pushVariant(inner_state, arg1.call("__index", Ref<LuaAPI>(api), arg2));
@@ -460,6 +461,8 @@ void LuaState::createObjectMetatable() {
 	});
 
 	LUA_METAMETHOD_TEMPLATE(L, -1, "__newindex", {
+		Ref<LuaAPI> api = getAPI(inner_state);
+
 		// If object overrides
 		if (arg1.has_method("__newindex")) {
 			LuaState::pushVariant(inner_state, arg1.call("__newindex", Ref<LuaAPI>(api), arg2, arg3));
@@ -489,10 +492,10 @@ void LuaState::createObjectMetatable() {
 
 		Array args;
 		for (int i = 1; i < argc; i++) {
-			args.push_back(LuaState::getVariant(inner_state, i + 1, api));
+			args.push_back(LuaState::getVariant(inner_state, i + 1));
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__call", Ref<LuaAPI>(api), LuaTuple::fromArray(args)));
+		LuaState::pushVariant(inner_state, arg1.call("__call", Ref<LuaAPI>(getAPI(inner_state)), LuaTuple::fromArray(args)));
 		return 1;
 	});
 
@@ -507,7 +510,7 @@ void LuaState::createObjectMetatable() {
 		}
 
 		// just in case they want to raise an error
-		Variant ret = arg1.call("__gc", api);
+		Variant ret = arg1.call("__gc", getAPI(inner_state));
 		if (LuaError *err = dynamic_cast<LuaError *>(ret.operator Object *())) {
 			LuaState::pushVariant(inner_state, ret);
 		}
@@ -520,7 +523,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__tostring", api));
+		LuaState::pushVariant(inner_state, arg1.call("__tostring"));
 		return 1;
 	});
 
@@ -530,7 +533,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__metatable", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__metatable", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -540,7 +543,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__len", api));
+		LuaState::pushVariant(inner_state, arg1.call("__len"));
 		return 1;
 	});
 
@@ -550,7 +553,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__unm", api));
+		LuaState::pushVariant(inner_state, arg1.call("__unm"));
 		return 1;
 	});
 
@@ -560,7 +563,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__add", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__add", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -570,7 +573,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__sub", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__sub", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -580,7 +583,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__mul", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__mul", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -590,7 +593,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__div", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__div", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -600,7 +603,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__idiv", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__idiv", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -610,7 +613,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__mod", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__mod", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -620,7 +623,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__pow", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__pow", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -630,7 +633,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__concat", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__concat", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -640,7 +643,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__band", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__band", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -650,7 +653,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__bor", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__bor", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -660,7 +663,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__bxor", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__bxor", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -670,7 +673,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__bnot", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__bnot", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -680,7 +683,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__shl", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__shl", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -690,7 +693,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__shr", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__shr", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -700,7 +703,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__eq", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__eq", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -710,7 +713,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__lt", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__lt", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 
@@ -720,7 +723,7 @@ void LuaState::createObjectMetatable() {
 			return 0;
 		}
 
-		LuaState::pushVariant(inner_state, arg1.call("__le", Ref<LuaAPI>(api), arg2));
+		LuaState::pushVariant(inner_state, arg1.call("__le", Ref<LuaAPI>(getAPI(inner_state)), arg2));
 		return 1;
 	});
 


### PR DESCRIPTION
This should result in some small performance improvements as we avoid pulling the api ref from the state unless needed now. This PR also adds support to move a lua funcref from one state to another.