### PR TITLE
Add max memory usage restrictions

### DIFF
--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -104,10 +104,20 @@
 			<description>
 				Controls the garbage collector. The option can be one of the following: [code]GC_STOP[/code], [code]GC_RESTART[/code], [code]GC_COLLECT[/code], [code]GC_COUNT[/code], [code]GC_STEP[/code], [code]GC_SETPAUSE[/code], [code]GC_SETSTEPMUL[/code]. The data is the argument for the option. Returns the result of the option.
 			</description>
+		</method>
+		<method name="get_memory_usage">
+			<return type="int" />
+			<description>
+				Returns the current memory usage of the state in bytes.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="permissive" type="bool" setter="set_permissive" getter="get_permissive" default="true">
 			When set to true all methods will be allowed on Objects be default and lua_fields is treated as a blacklist. When set to false, lua_fields is treated as a whitelist.
+		</member>
+		<member name="memory_limit" type="int" setter="set_memory_limit" getter="get_memory_limit" default="0">
+			Sets the memory limit for the state in bytes. If the limit is 0, there is no limit.
 		</member>
 	</members>
 	<constants>

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -32,17 +32,14 @@ public:
 	void bindLibraries(Array libs);
 	void setHook(Callable hook, int mask, int count);
 
-	inline int configure_gc(int what, int data) {
-		return lua_gc(lState, what, data);
-	}
+	void setPermissive(bool value);
+	bool getPermissive() const;
 
-	inline void setPermissive(bool value) {
-		permissive = value;
-	}
+	void setMemoryLimit(int limit);
+	int getMemoryLimit() const;
 
-	inline bool getPermissive() const {
-		return permissive;
-	}
+	int configureGC(int what, int data);
+	int getMemoryUsage() const;
 
 	bool luaFunctionExists(String functionName);
 
@@ -82,6 +79,15 @@ public:
 private:
 	LuaState state;
 	lua_State *lState = nullptr;
+
+	static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize);
+
+	struct LuaAllocData {
+		int memoryUsed = 0;
+		int memoryLimit = 0;
+	};
+
+	LuaAllocData luaAllocData;
 
 	bool permissive = true;
 


### PR DESCRIPTION
This PR adds the ability to control the max amount of memory the Lua state can use.

## Added
- **memory_limit property** this sets the max allowed memory usage in bytes, if 0 there is no limit. Defaults to 0
- **get_memory_usage method** this returns the current memory usage of the Lua state in bytes.