### PR TITLE
Remove expose_constructor

### DIFF
--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -41,14 +41,6 @@
 				Loads a string with luaL_loadstring() and executes the top of the stack. Returns any errors.
 			</description>
 		</method>
-		<method name="expose_constructor">
-			<return type="LuaError" />
-			<param index="0" name="LuaConstructorName" type="String" />
-			<param index="1" name="Object" type="Object" />
-			<description>
-				Accepts any object that has a new() method. Allows lua to call the constructor aka the new() method. Exposed as a global with the given name.
-			</description>
-		</method>
 		<method name="function_exists">
 			<return type="bool" />
 			<param index="0" name="LuaFunctionName" type="String" />

--- a/project/testing/tests/LuaAPI.expose_constructor.gd
+++ b/project/testing/tests/LuaAPI.expose_constructor.gd
@@ -13,7 +13,7 @@ func _ready():
 
 	lua = LuaAPI.new()
 	lua.permissive = true
-	var err = lua.expose_constructor("TestObj", TestObject)
+	var err = lua.push_variant("TestObj", TestObject.new)
 	if err is LuaError:
 		errors.append(err)
 		fail()
@@ -21,7 +21,7 @@ func _ready():
 	# testName and testDescription are for any needed context about the test.
 	testName = "LuaAPI.expose_constructor"
 	testDescription = "
-Test LuaAPI.expose_constructor.
+Test LuaAPI.push_variant with a object constructor.
 Exoposes a object constructor for TestObject which contains one variable. A string
 lua calls the constructor and then sets the string to 'Hello from lua!'.
 We also test pulling it back to GD and confirm the contents of the string.

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -28,7 +28,6 @@ void LuaAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("configure_gc", "What", "Data"), &LuaAPI::configure_gc);
 	ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
 	ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
-	ClassDB::bind_method(D_METHOD("expose_constructor", "LuaConstructorName", "Object"), &LuaAPI::exposeObjectConstructor);
 	ClassDB::bind_method(D_METHOD("call_function", "LuaFunctionName", "Args"), &LuaAPI::callFunction);
 	ClassDB::bind_method(D_METHOD("call_function_ref", "Args", "LuaFunctionRef"), &LuaAPI::callFunctionRef);
 	ClassDB::bind_method(D_METHOD("function_exists", "LuaFunctionName"), &LuaAPI::luaFunctionExists);
@@ -108,11 +107,6 @@ Variant LuaAPI::callFunctionRef(Array args, int funcRef) {
 // Calls LuaState::pushGlobalVariant()
 LuaError *LuaAPI::pushGlobalVariant(String name, Variant var) {
 	return state.pushGlobalVariant(name, var);
-}
-
-// Calls LuaState::exposeObjectConstructor()
-LuaError *LuaAPI::exposeObjectConstructor(String name, Object *obj) {
-	return state.exposeObjectConstructor(name, obj);
 }
 
 // addFile() calls luaL_loadfille with the absolute file path

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -53,7 +53,6 @@ public:
 	LuaError *doFile(String fileName);
 	LuaError *doString(String code);
 	LuaError *pushGlobalVariant(String name, Variant var);
-	LuaError *exposeObjectConstructor(String name, Object *obj);
 
 	Ref<LuaCoroutine> newCoroutine();
 	Ref<LuaCoroutine> getRunningCoroutine();

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -31,7 +31,6 @@ public:
 
 	LuaError *pushVariant(Variant var) const;
 	LuaError *pushGlobalVariant(String name, Variant var);
-	LuaError *exposeObjectConstructor(String name, Object *obj);
 	LuaError *handleError(int lua_error) const;
 
 	static LuaAPI *getAPI(lua_State *state);

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -22,32 +22,6 @@
 	lua_pushcfunction(lua_state, LUA_LAMBDA_TEMPLATE(_f_));                       \
 	lua_settable(lua_state, metatable_index - 2);
 
-// Expose the constructor for a object to lua
-LuaError *LuaState::exposeObjectConstructor(String name, Object *obj) {
-	// Make sure we are able to call new
-	if (!obj->has_method("new")) {
-		return LuaError::newError("during \"LuaState::exposeObjectConstructor\" method 'new' does not exist.", LuaError::ERR_RUNTIME);
-	}
-	lua_pushlightuserdata(L, obj);
-
-	lua_pushcclosure(L, LUA_LAMBDA_TEMPLATE({
-		Object *inner_obj = (Object *)lua_touserdata(inner_state, lua_upvalueindex(1));
-
-		Variant *userdata = (Variant *)lua_newuserdata(inner_state, sizeof(Variant));
-		Variant ret = inner_obj->call("new");
-
-		memnew_placement(userdata, Variant(ret));
-
-		luaL_setmetatable(inner_state, "mt_Object");
-
-		return 1;
-	}),
-			1);
-
-	lua_setglobal(L, name.ascii().get_data());
-	return nullptr;
-}
-
 // Expose the default constructors
 void LuaState::exposeConstructors() {
 	lua_pushcfunction(L, LUA_LAMBDA_TEMPLATE({


### PR DESCRIPTION
Now that our memory management is streamlined there is no need to treat objects made by lua any different making expose_constructor obsolete. Instead you can either return or push obj.new as a global. This also allows for constructor args.