### PR TITLE
Cleanup

### DIFF
--- a/.github/workflows/gdextension.yml
+++ b/.github/workflows/gdextension.yml
@@ -183,6 +183,7 @@ jobs:
         if: ${{ startsWith(matrix.opts.identifier, 'windows-') }}
         shell: sh
         run: |
+          sudo apt-get update
           sudo apt-get install mingw-w64
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
@@ -237,7 +238,7 @@ jobs:
       - name: Compile extension
         shell: sh
         run: |
-          scons target='${{ matrix.opts.target }}' platform='${{ matrix.opts.platform }}' arch='${{ matrix.opts.arch }}' ${{ matrix.opts.args }}
+          PATH=/opt/buildroot/bin:$PATH scons target='${{ matrix.opts.target }}' platform='${{ matrix.opts.platform }}' arch='${{ matrix.opts.arch }}' ${{ matrix.opts.args }}
           ls -l project/addons/luaAPI/bin/
       - name: Strip bins
         if: "!startsWith(matrix.opts.identifier, 'windows-') && startsWith(matrix.opts.arch, 'x86_')"
@@ -360,6 +361,7 @@ jobs:
         if: ${{ startsWith(matrix.opts.identifier, 'windows-') }}
         shell: sh
         run: |
+          sudo apt-get update
           sudo apt-get install mingw-w64
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix
           sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -91,6 +91,7 @@ jobs:
         if: ${{ matrix.opts.runner != 'windows-latest' }}
         shell: sh
         run: |
+          sudo apt update
           sudo apt install gcc-multilib g++-multilib
           sudo apt-get install mingw-w64
           sudo update-alternatives --set x86_64-w64-mingw32-gcc /usr/bin/x86_64-w64-mingw32-gcc-posix

--- a/doc_classes/LuaObjectMetatable.xml
+++ b/doc_classes/LuaObjectMetatable.xml
@@ -58,7 +58,7 @@
 			<param index="1" name="lua" type="LuaAPI" />
 			<param index="2" name="args" type="LuaTuple" />
 			<description>
-                The bitwise NOT (unary ~) operation. Behavior similar to the bitwise AND operation.
+                The call operation. Used when the object is called as a function.
 			</description>
 		</method>
 		<method name="__concat" qualifiers="virtual">
@@ -109,12 +109,10 @@
 			<return type="Variant" />
 			<param index="0" name="obj" type="Object" />
 			<param index="1" name="lua" type="LuaAPI" />
-			<param index="2" name="index" type="String" />
+			<param index="2" name="index" type="Variant" />
 			<description>
                 The indexing access operation table[key]. This event happens when table is not a table or when key is not present in table. The metavalue is looked up in the metatable of table.
-                
-                The metavalue for this event can be either a function, a table, or any value with an __index metavalue. If it is a function, it is called with table and key as arguments, and the result of the call (adjusted to one value) is the result of the operation. Otherwise, the final result is the result of indexing this metavalue with key. This indexing is regular, not raw, and therefore can trigger another __index metavalue. 
-			</description>
+            </description>
 		</method>
 		<method name="__le" qualifiers="virtual">
 			<return type="bool" />
@@ -172,7 +170,7 @@
 			<return type="LuaError" />
 			<param index="0" name="obj" type="Object" />
 			<param index="1" name="lua" type="LuaAPI" />
-			<param index="2" name="index" type="String" />
+			<param index="2" name="index" type="Variant" />
 			<param index="3" name="value" type="Variant" />
 			<description>
                 The indexing assignment table[key] = value. Like the index event, this event happens when table is not a table or when key is not present in table. The metavalue is looked up in the metatable of table.

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -139,12 +139,12 @@ Variant LuaAPI::callFunctionRef(Array args, int funcRef) {
 }
 
 // Calls LuaState::pushGlobalVariant()
-LuaError *LuaAPI::pushGlobalVariant(String name, Variant var) {
+Ref<LuaError> LuaAPI::pushGlobalVariant(String name, Variant var) {
 	return state.pushGlobalVariant(name, var);
 }
 
 // addFile() calls luaL_loadfille with the absolute file path
-LuaError *LuaAPI::doFile(String fileName) {
+Ref<LuaError> LuaAPI::doFile(String fileName) {
 	// push the error handler onto the stack
 	lua_pushcfunction(lState, LuaState::luaErrorHandler);
 
@@ -172,14 +172,14 @@ LuaError *LuaAPI::doFile(String fileName) {
 		return state.handleError(ret);
 	}
 
-	LuaError *err = execute(-2);
+	Ref<LuaError> err = execute(-2);
 	// pop the error handler from the stack
 	lua_pop(lState, 1);
 	return err;
 }
 
 // Loads string into lua state and executes the top of the stack
-LuaError *LuaAPI::doString(String code) {
+Ref<LuaError> LuaAPI::doString(String code) {
 	// push the error handler onto the stack
 	lua_pushcfunction(lState, LuaState::luaErrorHandler);
 	int ret = luaL_loadstring(lState, code.ascii().get_data());
@@ -187,14 +187,14 @@ LuaError *LuaAPI::doString(String code) {
 		return state.handleError(ret);
 	}
 
-	LuaError *err = execute(-2);
+	Ref<LuaError> err = execute(-2);
 	// pop the error handler from the stack
 	lua_pop(lState, 1);
 	return err;
 }
 
 // Execute the current lua stack, return error as string if one occurs, otherwise return String()
-LuaError *LuaAPI::execute(int handlerIndex) {
+Ref<LuaError> LuaAPI::execute(int handlerIndex) {
 	int ret = lua_pcall(lState, 0, 0, handlerIndex);
 	if (ret != LUA_OK) {
 		return state.handleError(ret);

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -86,15 +86,15 @@ Ref<LuaObjectMetatable> LuaAPI::getObjectMetatable() const {
 	return objectMetatable;
 }
 
-void LuaAPI::setMemoryLimit(int limit) {
+void LuaAPI::setMemoryLimit(uint64_t limit) {
 	luaAllocData.memoryLimit = limit;
 }
 
-int LuaAPI::getMemoryLimit() const {
+uint64_t LuaAPI::getMemoryLimit() const {
 	return luaAllocData.memoryLimit;
 }
 
-int LuaAPI::getMemoryUsage() const {
+uint64_t LuaAPI::getMemoryUsage() const {
 	return luaAllocData.memoryUsed;
 }
 
@@ -244,19 +244,19 @@ void *LuaAPI::luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize) {
 	}
 
 	if (ptr == nullptr) {
-		if (data->memoryLimit != 0 && data->memoryUsed + (int)nsize > data->memoryLimit) {
+		if (data->memoryLimit != 0 && data->memoryUsed + (uint64_t)nsize > data->memoryLimit) {
 			return nullptr;
 		}
 
-		data->memoryUsed += (int)nsize;
+		data->memoryUsed += (uint64_t)nsize;
 		return memalloc(nsize);
 	}
 
-	if (data->memoryLimit != 0 && data->memoryUsed - (int)osize + (int)nsize > data->memoryLimit) {
+	if (data->memoryLimit != 0 && data->memoryUsed - (uint64_t)osize + (uint64_t)nsize > data->memoryLimit) {
 		return nullptr;
 	}
 
-	data->memoryUsed -= (int)osize;
-	data->memoryUsed += (int)nsize;
+	data->memoryUsed -= (uint64_t)osize;
+	data->memoryUsed += (uint64_t)nsize;
 	return memrealloc(ptr, nsize);
 }

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -36,11 +36,11 @@ public:
 	void setObjectMetatable(Ref<LuaObjectMetatable> value);
 	Ref<LuaObjectMetatable> getObjectMetatable() const;
 
-	void setMemoryLimit(int limit);
-	int getMemoryLimit() const;
+	void setMemoryLimit(uint64_t limit);
+	uint64_t getMemoryLimit() const;
 
 	int configureGC(int what, int data);
-	int getMemoryUsage() const;
+	uint64_t getMemoryUsage() const;
 
 	bool luaFunctionExists(String functionName);
 
@@ -85,8 +85,8 @@ private:
 	static void *luaAlloc(void *ud, void *ptr, size_t osize, size_t nsize);
 
 	struct LuaAllocData {
-		int memoryUsed = 0;
-		int memoryLimit = 0;
+		uint64_t memoryUsed = 0;
+		uint64_t memoryLimit = 0;
 	};
 
 	LuaAllocData luaAllocData;

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -48,9 +48,9 @@ public:
 	Variant callFunction(String functionName, Array args);
 	Variant callFunctionRef(Array args, int funcRef);
 
-	LuaError *doFile(String fileName);
-	LuaError *doString(String code);
-	LuaError *pushGlobalVariant(String name, Variant var);
+	Ref<LuaError> doFile(String fileName);
+	Ref<LuaError> doString(String code);
+	Ref<LuaError> pushGlobalVariant(String name, Variant var);
 
 	Ref<LuaCoroutine> newCoroutine();
 	Ref<LuaCoroutine> getRunningCoroutine();
@@ -91,7 +91,7 @@ private:
 
 	LuaAllocData luaAllocData;
 
-	LuaError *execute(int handlerIndex);
+	Ref<LuaError> execute(int handlerIndex);
 };
 
 VARIANT_ENUM_CAST(LuaAPI::HookMask)

--- a/src/classes/luaCallableExtra.cpp
+++ b/src/classes/luaCallableExtra.cpp
@@ -39,16 +39,16 @@ void LuaCallableExtra::setInfo(Callable function, int argc, bool isTuple, bool w
 	this->wantsRef = wantsRef;
 }
 
-void LuaCallableExtra::setTuple(bool isTuple) {
-	this->isTuple = isTuple;
+void LuaCallableExtra::setTuple(bool value) {
+	this->isTuple = value;
 }
 
-void LuaCallableExtra::setWantsRef(bool wantsRef) {
-	this->wantsRef = wantsRef;
+void LuaCallableExtra::setWantsRef(bool value) {
+	this->wantsRef = value;
 }
 
-void LuaCallableExtra::setArgc(int argc) {
-	this->argc = argc;
+void LuaCallableExtra::setArgc(int value) {
+	this->argc = value;
 }
 
 bool LuaCallableExtra::getTuple() {

--- a/src/classes/luaCallableExtra.cpp
+++ b/src/classes/luaCallableExtra.cpp
@@ -127,20 +127,23 @@ int LuaCallableExtra::call(lua_State *state) {
 	return 1;
 }
 
-LuaCallableExtra *LuaCallableExtra::withTuple(Callable func, int argc) {
-	LuaCallableExtra *toReturn = memnew(LuaCallableExtra);
+Ref<LuaCallableExtra> LuaCallableExtra::withTuple(Callable func, int argc) {
+	Ref<LuaCallableExtra> toReturn;
+	toReturn.instantiate();
 	toReturn->setInfo(func, argc, true, false);
 	return toReturn;
 }
 
-LuaCallableExtra *LuaCallableExtra::withRef(Callable func) {
-	LuaCallableExtra *toReturn = memnew(LuaCallableExtra);
+Ref<LuaCallableExtra> LuaCallableExtra::withRef(Callable func) {
+	Ref<LuaCallableExtra> toReturn;
+	toReturn.instantiate();
 	toReturn->setInfo(func, 0, false, true);
 	return toReturn;
 }
 
-LuaCallableExtra *LuaCallableExtra::withRefAndTuple(Callable func, int argc) {
-	LuaCallableExtra *toReturn = memnew(LuaCallableExtra);
+Ref<LuaCallableExtra> LuaCallableExtra::withRefAndTuple(Callable func, int argc) {
+	Ref<LuaCallableExtra> toReturn;
+	toReturn.instantiate();
 	toReturn->setInfo(func, argc, true, true);
 	return toReturn;
 }

--- a/src/classes/luaCallableExtra.cpp
+++ b/src/classes/luaCallableExtra.cpp
@@ -69,8 +69,7 @@ int LuaCallableExtra::call(lua_State *state) {
 	int noneMulty = l_argc;
 	LuaCallableExtra *func = (LuaCallableExtra *)LuaState::getVariant(state, 1).operator Object *();
 	if (func == nullptr) {
-		LuaError *err = LuaError::newError("Error during LuaCallableExtra::call func==null", LuaError::ERR_RUNTIME);
-		lua_pushstring(state, err->getMessage().ascii().get_data());
+		lua_pushstring(state, "Error during LuaCallableExtra::call func==null");
 		lua_error(state);
 		return 0;
 	}
@@ -111,7 +110,7 @@ int LuaCallableExtra::call(lua_State *state) {
 	Callable::CallError error;
 	func->function.callp(p_args, args.size(), returned, error);
 	if (error.error != error.CALL_OK) {
-		LuaError *err = LuaState::handleError(func->function.get_method(), error, p_args, args.size());
+		Ref<LuaError> err = LuaState::handleError(func->function.get_method(), error, p_args, args.size());
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return 0;

--- a/src/classes/luaCallableExtra.h
+++ b/src/classes/luaCallableExtra.h
@@ -22,9 +22,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	static LuaCallableExtra *withTuple(Callable function, int argc);
-	static LuaCallableExtra *withRef(Callable function);
-	static LuaCallableExtra *withRefAndTuple(Callable function, int argc);
+	static Ref<LuaCallableExtra> withTuple(Callable function, int argc);
+	static Ref<LuaCallableExtra> withRef(Callable function);
+	static Ref<LuaCallableExtra> withRefAndTuple(Callable function, int argc);
 
 	void setInfo(Callable function, int argc, bool isTuple, bool wantsRef);
 

--- a/src/classes/luaCallableExtra.h
+++ b/src/classes/luaCallableExtra.h
@@ -28,13 +28,13 @@ public:
 
 	void setInfo(Callable function, int argc, bool isTuple, bool wantsRef);
 
-	void setTuple(bool isTuple);
+	void setTuple(bool value);
 	bool getTuple();
 
-	void setWantsRef(bool wantsRef);
+	void setWantsRef(bool value);
 	bool getWantsRef();
 
-	void setArgc(int argc);
+	void setArgc(int value);
 	int getArgc();
 
 	static int call(lua_State *state);

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -39,10 +39,10 @@ void LuaCoroutine::bind(Ref<LuaAPI> lua) {
 }
 
 // binds the thread to a lua object
-void LuaCoroutine::bindExisting(Ref<LuaAPI> lua, lua_State *tState) {
+void LuaCoroutine::bindExisting(Ref<LuaAPI> lua, lua_State *L) {
 	done = false;
 	parent = lua;
-	this->tState = tState;
+	this->tState = L;
 	state.setState(tState, lua.ptr(), false);
 
 	// register the yield method

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -56,8 +56,8 @@ void LuaCoroutine::setHook(Callable hook, int mask, int count) {
 Signal LuaCoroutine::yieldAwait(Array args) {
 	lua_pop(tState, 1); // Pop function off top of stack.
 	for (int i = 0; i < args.size(); i++) {
-		LuaError *err = state.pushVariant(args[i]);
-		if (err != nullptr) {
+		Ref<LuaError> err = state.pushVariant(args[i]);
+		if (!err.is_null()) {
 			// Raise an error on the lua state, error should be passed to reumse()
 			state.pushVariant(err);
 		}
@@ -76,7 +76,7 @@ Variant LuaCoroutine::pullVariant(String name) {
 }
 
 // Calls LuaState::pushGlobalVariant()
-LuaError *LuaCoroutine::pushGlobalVariant(String name, Variant var) {
+Ref<LuaError> LuaCoroutine::pushGlobalVariant(String name, Variant var) {
 	return state.pushGlobalVariant(name, var);
 }
 
@@ -86,7 +86,7 @@ Variant LuaCoroutine::callFunction(String functionName, Array args) {
 }
 
 // loads a string into the threads state
-LuaError *LuaCoroutine::loadString(String code) {
+Ref<LuaError> LuaCoroutine::loadString(String code) {
 	done = false;
 	int ret = luaL_loadstring(tState, code.ascii().get_data());
 	if (ret != LUA_OK) {
@@ -95,7 +95,7 @@ LuaError *LuaCoroutine::loadString(String code) {
 	return nullptr;
 }
 
-LuaError *LuaCoroutine::loadFile(String fileName) {
+Ref<LuaError> LuaCoroutine::loadFile(String fileName) {
 #ifndef LAPI_GDEXTENSION
 	done = false;
 	Error error;
@@ -119,14 +119,14 @@ LuaError *LuaCoroutine::loadFile(String fileName) {
 	return nullptr;
 }
 
-LuaError *LuaCoroutine::yield(Array args) {
+Ref<LuaError> LuaCoroutine::yield(Array args) {
 	Array ret;
 	if (int count = lua_gettop(tState); count > 0) {
 		lua_pop(tState, count);
 	}
 	for (int i = 0; i < args.size(); i++) {
-		LuaError *err = state.pushVariant(args[i]);
-		if (err != nullptr) {
+		Ref<LuaError> err = state.pushVariant(args[i]);
+		if (!err.is_null()) {
 			return err;
 		}
 	}
@@ -177,8 +177,8 @@ Variant LuaCoroutine::resume(Array args) {
 	}
 
 	for (int i = 0; i < args.size(); i++) {
-		LuaError *err = state.pushVariant(args[i]);
-		if (err != nullptr) {
+		Ref<LuaError> err = state.pushVariant(args[i]);
+		if (!err.is_null()) {
 			return err;
 		}
 	}
@@ -233,8 +233,8 @@ Variant LuaCoroutine::resume(Array args) {
 	}
 
 	for (int i = 0; i < args.size(); i++) {
-		LuaError *err = state.pushVariant(args[i]);
-		if (err != nullptr) {
+		Ref<LuaError> err = state.pushVariant(args[i]);
+		if (!err.is_null()) {
 			return err;
 		}
 	}

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -27,7 +27,7 @@ protected:
 
 public:
 	void bind(Ref<LuaAPI> lua);
-	void bindExisting(Ref<LuaAPI> lua, lua_State *tState);
+	void bindExisting(Ref<LuaAPI> lua, lua_State *L);
 	void setHook(Callable hook, int mask, int count);
 
 	Signal yieldAwait(Array args);

--- a/src/classes/luaCoroutine.h
+++ b/src/classes/luaCoroutine.h
@@ -34,10 +34,10 @@ public:
 
 	bool luaFunctionExists(String functionName);
 
-	LuaError *loadString(String code);
-	LuaError *loadFile(String fileName);
-	LuaError *pushGlobalVariant(String name, Variant var);
-	LuaError *yield(Array args);
+	Ref<LuaError> loadString(String code);
+	Ref<LuaError> loadFile(String fileName);
+	Ref<LuaError> pushGlobalVariant(String name, Variant var);
+	Ref<LuaError> yield(Array args);
 
 	Variant resume(Array args);
 	Variant pullVariant(String name);

--- a/src/classes/luaError.cpp
+++ b/src/classes/luaError.cpp
@@ -21,8 +21,9 @@ void LuaError::_bind_methods() {
 }
 
 // Create a new error
-LuaError *LuaError::newError(String msg, ErrorType type) {
-	LuaError *err = memnew(LuaError);
+Ref<LuaError> LuaError::newError(String msg, ErrorType type) {
+	Ref<LuaError> err;
+	err.instantiate();
 	err->setInfo(msg, static_cast<LuaError::ErrorType>(type));
 	return err;
 }

--- a/src/classes/luaError.h
+++ b/src/classes/luaError.h
@@ -29,7 +29,7 @@ public:
 		ERR_ERR = LUA_ERRERR,
 		ERR_FILE = LUA_ERRFILE,
 	};
-	static LuaError *newError(String msg, ErrorType type);
+	static Ref<LuaError> newError(String msg, ErrorType type);
 
 	void setInfo(String msg, ErrorType type);
 	bool operator==(const ErrorType type);

--- a/src/classes/luaObjectMetatable.cpp
+++ b/src/classes/luaObjectMetatable.cpp
@@ -41,13 +41,9 @@ Variant LuaObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, Variant index)
 	return ret;
 }
 
-LuaError *LuaObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) {
-	LuaError *ret = nullptr;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__newindex, obj, api, index, value, ret);
-#else
-	ret = dynamic_cast<LuaError *>((Object *)call("__newindex", obj, api, index, value));
-#endif
+Ref<LuaError> LuaObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) {
+	Ref<LuaError> ret;
+	VIRTUAL_CALL(__newindex, ret, obj, api, index, value);
 	return ret;
 }
 
@@ -57,13 +53,9 @@ Variant LuaObjectMetatable::__call(Object *obj, Ref<LuaAPI> api, Ref<LuaTuple> a
 	return ret;
 }
 
-LuaError *LuaObjectMetatable::__gc(Object *obj, Ref<LuaAPI> api) {
-	LuaError *ret = nullptr;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__gc, obj, api, ret);
-#else
-	ret = dynamic_cast<LuaError *>((Object *)call("__gc", obj, api));
-#endif
+Ref<LuaError> LuaObjectMetatable::__gc(Object *obj, Ref<LuaAPI> api) {
+	Ref<LuaError> ret;
+	VIRTUAL_CALL(__gc, ret, obj, api);
 	return ret;
 }
 
@@ -219,14 +211,14 @@ Variant LuaDefaultObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, Variant
 		fields = obj->call("lua_fields");
 	}
 
-	if ((!permissive && fields.has(index)) || (permissive && !fields.has(index))) {
-		return obj->get(index);
+	if ((!permissive && fields.has((String)index)) || (permissive && !fields.has((String)index))) {
+		return obj->get((String)index);
 	}
 
 	return Variant();
 }
 
-LuaError *LuaDefaultObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) {
+Ref<LuaError> LuaDefaultObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) {
 	if (obj->has_method("__newindex")) {
 		Variant ret = obj->call("__newindex", api, index, value);
 		if (ret.get_type() == Variant::OBJECT) {
@@ -259,7 +251,7 @@ Variant LuaDefaultObjectMetatable::__call(Object *obj, Ref<LuaAPI> api, Ref<LuaT
 	return Variant();
 }
 
-LuaError *LuaDefaultObjectMetatable::__gc(Object *obj, Ref<LuaAPI> api) {
+Ref<LuaError> LuaDefaultObjectMetatable::__gc(Object *obj, Ref<LuaAPI> api) {
 	if (obj->has_method("__gc")) {
 		Variant ret = obj->call("__gc", api);
 		if (ret.get_type() == Variant::OBJECT) {

--- a/src/classes/luaObjectMetatable.cpp
+++ b/src/classes/luaObjectMetatable.cpp
@@ -2,6 +2,9 @@
 
 #ifdef LAPI_GDEXTENSION
 #define GDVIRTUAL_BIND(m, ...) BIND_VIRTUAL_METHOD(LuaObjectMetatable, m);
+#define VIRTUAL_CALL(m, r, ...) r = call(#m, __VA_ARGS__);
+#else
+#define VIRTUAL_CALL(m, r, ...) GDVIRTUAL_CALL(m, __VA_ARGS__, r);
 #endif
 
 void LuaObjectMetatable::_bind_methods() {
@@ -32,17 +35,13 @@ void LuaObjectMetatable::_bind_methods() {
 	GDVIRTUAL_BIND(__le, "obj", "lua", "other");
 }
 
-Variant LuaObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, String index) {
+Variant LuaObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, Variant index) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__index, obj, api, index, ret);
-#else
-	ret = call("__index", obj, api, index);
-#endif
+	VIRTUAL_CALL(__index, ret, obj, api, index);
 	return ret;
 }
 
-LuaError *LuaObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, String index, Variant value) {
+LuaError *LuaObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) {
 	LuaError *ret = nullptr;
 #ifndef LAPI_GDEXTENSION
 	GDVIRTUAL_CALL(__newindex, obj, api, index, value, ret);
@@ -54,11 +53,7 @@ LuaError *LuaObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, String in
 
 Variant LuaObjectMetatable::__call(Object *obj, Ref<LuaAPI> api, Ref<LuaTuple> args) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__call, obj, api, args, ret);
-#else
-	ret = call("__call", obj, api, args);
-#endif
+	VIRTUAL_CALL(__call, ret, obj, api, args);
 	return ret;
 }
 
@@ -74,211 +69,127 @@ LuaError *LuaObjectMetatable::__gc(Object *obj, Ref<LuaAPI> api) {
 
 String LuaObjectMetatable::__tostring(Object *obj, Ref<LuaAPI> api) {
 	String ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__tostring, obj, api, ret);
-#else
-	ret = call("__tostring", obj, api);
-#endif
+	VIRTUAL_CALL(__tostring, ret, obj, api);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__metatable(Object *obj, Ref<LuaAPI> api) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__metatable, obj, api, ret);
-#else
-	ret = call("__metatable", obj, api);
-#endif
+	VIRTUAL_CALL(__metatable, ret, obj, api);
 	return ret;
 }
 
 int LuaObjectMetatable::__len(Object *obj, Ref<LuaAPI> api) {
 	int ret = 0;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__len, obj, api, ret);
-#else
-	ret = call("__len", obj, api);
-#endif
+	VIRTUAL_CALL(__len, ret, obj, api);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__unm(Object *obj, Ref<LuaAPI> api) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__unm, obj, api, ret);
-#else
-	ret = call("__unm", obj, api);
-#endif
+	VIRTUAL_CALL(__unm, ret, obj, api);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__add(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__add, obj, api, other, ret);
-#else
-	ret = call("__add", obj, api, other);
-#endif
+	VIRTUAL_CALL(__add, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__sub(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__sub, obj, api, other, ret);
-#else
-	ret = call("__sub", obj, api, other);
-#endif
+	VIRTUAL_CALL(__sub, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__mul(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__mul, obj, api, other, ret);
-#else
-	ret = call("__mul", obj, api, other);
-#endif
+	VIRTUAL_CALL(__mul, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__div(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__div, obj, api, other, ret);
-#else
-	ret = call("__div", obj, api, other);
-#endif
+	VIRTUAL_CALL(__div, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__idiv(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__idiv, obj, api, other, ret);
-#else
-	ret = call("__idiv", obj, api, other);
-#endif
+	VIRTUAL_CALL(__idiv, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__mod(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__mod, obj, api, other, ret);
-#else
-	ret = call("__mod", obj, api, other);
-#endif
+	VIRTUAL_CALL(__mod, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__pow(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__pow, obj, api, other, ret);
-#else
-	ret = call("__pow", obj, api, other);
-#endif
+	VIRTUAL_CALL(__pow, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__band(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__band, obj, api, other, ret);
-#else
-	ret = call("__band", obj, api, other);
-#endif
+	VIRTUAL_CALL(__band, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__bor(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__bor, obj, api, other, ret);
-#else
-	ret = call("__bor", obj, api, other);
-#endif
+	VIRTUAL_CALL(__bor, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__bxor(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__bxor, obj, api, other, ret);
-#else
-	ret = call("__bxor", obj, api, other);
-#endif
+	VIRTUAL_CALL(__bxor, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__bnot(Object *obj, Ref<LuaAPI> api) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__bnot, obj, api, ret);
-#else
-	ret = call("__bnot", obj, api);
-#endif
+	VIRTUAL_CALL(__bnot, ret, obj, api);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__shl(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__shl, obj, api, other, ret);
-#else
-	ret = call("__shl", obj, api, other);
-#endif
+	VIRTUAL_CALL(__shl, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__shr(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__shr, obj, api, other, ret);
-#else
-	ret = call("__shr", obj, api, other);
-#endif
+	VIRTUAL_CALL(__shr, ret, obj, api, other);
 	return ret;
 }
 
 Variant LuaObjectMetatable::__concat(Object *obj, Ref<LuaAPI> api, Variant other) {
 	Variant ret;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__concat, obj, api, other, ret);
-#else
-	ret = call("__concat", obj, api, other);
-#endif
+	VIRTUAL_CALL(__concat, ret, obj, api, other);
 	return ret;
 }
 
 bool LuaObjectMetatable::__eq(Object *obj, Ref<LuaAPI> api, Variant other) {
 	bool ret = false;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__eq, obj, api, other, ret);
-#else
-	ret = call("__eq", obj, api, other);
-#endif
+	VIRTUAL_CALL(__eq, ret, obj, api, other);
 	return ret;
 }
 
 bool LuaObjectMetatable::__lt(Object *obj, Ref<LuaAPI> api, Variant other) {
 	bool ret = false;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__lt, obj, api, other, ret);
-#else
-	ret = call("__lt", obj, api, other);
-#endif
+	VIRTUAL_CALL(__lt, ret, obj, api, other);
 	return ret;
 }
 
 bool LuaObjectMetatable::__le(Object *obj, Ref<LuaAPI> api, Variant other) {
 	bool ret = false;
-#ifndef LAPI_GDEXTENSION
-	GDVIRTUAL_CALL(__le, obj, api, other, ret);
-#else
-	ret = call("__le", obj, api, other);
-#endif
+	VIRTUAL_CALL(__le, ret, obj, api, other);
 	return ret;
 }
 
@@ -298,7 +209,7 @@ bool LuaDefaultObjectMetatable::getPermissive() const {
 	return permissive;
 }
 
-Variant LuaDefaultObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, String index) {
+Variant LuaDefaultObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, Variant index) {
 	if (obj->has_method("__index")) {
 		return obj->call("__index", api, index);
 	}
@@ -315,7 +226,7 @@ Variant LuaDefaultObjectMetatable::__index(Object *obj, Ref<LuaAPI> api, String 
 	return Variant();
 }
 
-LuaError *LuaDefaultObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, String index, Variant value) {
+LuaError *LuaDefaultObjectMetatable::__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) {
 	if (obj->has_method("__newindex")) {
 		Variant ret = obj->call("__newindex", api, index, value);
 		if (ret.get_type() == Variant::OBJECT) {

--- a/src/classes/luaObjectMetatable.h
+++ b/src/classes/luaObjectMetatable.h
@@ -24,9 +24,9 @@ protected:
 
 #ifndef LAPI_GDEXTENSION
 	GDVIRTUAL3R(Variant, __index, Object *, Ref<LuaAPI>, Variant);
-	GDVIRTUAL4R(LuaError *, __newindex, Object *, Ref<LuaAPI>, Variant, Variant);
+	GDVIRTUAL4R(Ref<LuaError>, __newindex, Object *, Ref<LuaAPI>, Variant, Variant);
 	GDVIRTUAL3R(Variant, __call, Object *, Ref<LuaAPI>, Ref<LuaTuple>);
-	GDVIRTUAL2R(LuaError *, __gc, Object *, Ref<LuaAPI>);
+	GDVIRTUAL2R(Ref<LuaError>, __gc, Object *, Ref<LuaAPI>);
 	GDVIRTUAL2R(String, __tostring, Object *, Ref<LuaAPI>);
 	GDVIRTUAL2R(Variant, __metatable, Object *, Ref<LuaAPI>);
 	GDVIRTUAL2R(int, __len, Object *, Ref<LuaAPI>);
@@ -52,9 +52,9 @@ protected:
 
 public:
 	virtual Variant __index(Object *obj, Ref<LuaAPI> api, Variant index);
-	virtual LuaError *__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value);
+	virtual Ref<LuaError> __newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value);
 	virtual Variant __call(Object *obj, Ref<LuaAPI> api, Ref<LuaTuple> args);
-	virtual LuaError *__gc(Object *obj, Ref<LuaAPI> api);
+	virtual Ref<LuaError> __gc(Object *obj, Ref<LuaAPI> api);
 	virtual String __tostring(Object *obj, Ref<LuaAPI> api);
 	virtual Variant __metatable(Object *obj, Ref<LuaAPI> api);
 	virtual int __len(Object *obj, Ref<LuaAPI> api);
@@ -90,9 +90,9 @@ protected:
 
 public:
 	Variant __index(Object *obj, Ref<LuaAPI> api, Variant index) override;
-	LuaError *__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) override;
+	Ref<LuaError> __newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) override;
 	Variant __call(Object *obj, Ref<LuaAPI> api, Ref<LuaTuple> args) override;
-	LuaError *__gc(Object *obj, Ref<LuaAPI> api) override;
+	Ref<LuaError> __gc(Object *obj, Ref<LuaAPI> api) override;
 	String __tostring(Object *obj, Ref<LuaAPI> api) override;
 	Variant __metatable(Object *obj, Ref<LuaAPI> api) override;
 	int __len(Object *obj, Ref<LuaAPI> api) override;

--- a/src/classes/luaObjectMetatable.h
+++ b/src/classes/luaObjectMetatable.h
@@ -23,8 +23,8 @@ protected:
 	static void _bind_methods();
 
 #ifndef LAPI_GDEXTENSION
-	GDVIRTUAL3R(Variant, __index, Object *, Ref<LuaAPI>, String);
-	GDVIRTUAL4R(LuaError *, __newindex, Object *, Ref<LuaAPI>, String, Variant);
+	GDVIRTUAL3R(Variant, __index, Object *, Ref<LuaAPI>, Variant);
+	GDVIRTUAL4R(LuaError *, __newindex, Object *, Ref<LuaAPI>, Variant, Variant);
 	GDVIRTUAL3R(Variant, __call, Object *, Ref<LuaAPI>, Ref<LuaTuple>);
 	GDVIRTUAL2R(LuaError *, __gc, Object *, Ref<LuaAPI>);
 	GDVIRTUAL2R(String, __tostring, Object *, Ref<LuaAPI>);
@@ -51,8 +51,8 @@ protected:
 #endif
 
 public:
-	virtual Variant __index(Object *obj, Ref<LuaAPI> api, String index);
-	virtual LuaError *__newindex(Object *obj, Ref<LuaAPI> api, String index, Variant value);
+	virtual Variant __index(Object *obj, Ref<LuaAPI> api, Variant index);
+	virtual LuaError *__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value);
 	virtual Variant __call(Object *obj, Ref<LuaAPI> api, Ref<LuaTuple> args);
 	virtual LuaError *__gc(Object *obj, Ref<LuaAPI> api);
 	virtual String __tostring(Object *obj, Ref<LuaAPI> api);
@@ -89,8 +89,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	Variant __index(Object *obj, Ref<LuaAPI> api, String index) override;
-	LuaError *__newindex(Object *obj, Ref<LuaAPI> api, String index, Variant value) override;
+	Variant __index(Object *obj, Ref<LuaAPI> api, Variant index) override;
+	LuaError *__newindex(Object *obj, Ref<LuaAPI> api, Variant index, Variant value) override;
 	Variant __call(Object *obj, Ref<LuaAPI> api, Ref<LuaTuple> args) override;
 	LuaError *__gc(Object *obj, Ref<LuaAPI> api) override;
 	String __tostring(Object *obj, Ref<LuaAPI> api) override;

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -8,8 +8,8 @@
 
 #include <util.h>
 
-void LuaState::setState(lua_State *L, LuaAPI *api, bool bindAPI) {
-	this->L = L;
+void LuaState::setState(lua_State *state, LuaAPI *api, bool bindAPI) {
+	this->L = state;
 	if (!bindAPI) {
 		return;
 	}

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -187,21 +187,21 @@ Variant LuaState::callFunction(String functionName, Array args) {
 }
 
 // Push a GD Variant to the lua stack and returns a error if the type is not supported
-LuaError *LuaState::pushVariant(Variant var) const {
+Ref<LuaError> LuaState::pushVariant(Variant var) const {
 	return LuaState::pushVariant(L, var);
 }
 
 // Call pushVariant() and set it to a global name
-LuaError *LuaState::pushGlobalVariant(String name, Variant var) {
-	LuaError *err = pushVariant(var);
-	if (err == nullptr) {
+Ref<LuaError> LuaState::pushGlobalVariant(String name, Variant var) {
+	Ref<LuaError> err = pushVariant(var);
+	if (err.is_null()) {
 		lua_setglobal(L, name.ascii().get_data());
-		return err;
+		return nullptr;
 	}
 	return err;
 }
 
-LuaError *LuaState::handleError(int lua_error) const {
+Ref<LuaError> LuaState::handleError(int lua_error) const {
 	return LuaState::handleError(L, lua_error);
 }
 
@@ -219,7 +219,7 @@ LuaAPI *LuaState::getAPI(lua_State *state) {
 }
 
 // Push a GD Variant to the lua stack and returns a error if the type is not supported
-LuaError *LuaState::pushVariant(lua_State *state, Variant var) {
+Ref<LuaError> LuaState::pushVariant(lua_State *state, Variant var) {
 	switch (var.get_type()) {
 		case Variant::Type::NIL:
 			lua_pushnil(state);
@@ -253,13 +253,13 @@ LuaError *LuaState::pushVariant(lua_State *state, Variant var) {
 				Variant key = i + 1;
 				Variant value = array[i];
 
-				LuaError *err = pushVariant(state, key);
-				if (err != nullptr) {
+				Ref<LuaError> err = pushVariant(state, key);
+				if (!err.is_null()) {
 					return err;
 				}
 
 				err = pushVariant(state, value);
-				if (err != nullptr) {
+				if (!err.is_null()) {
 					return err;
 				}
 
@@ -276,13 +276,13 @@ LuaError *LuaState::pushVariant(lua_State *state, Variant var) {
 				Variant key = keys[i];
 				Variant value = dict[key];
 
-				LuaError *err = pushVariant(state, key);
-				if (err != nullptr) {
+				Ref<LuaError> err = pushVariant(state, key);
+				if (!err.is_null()) {
 					return err;
 				}
 
 				err = pushVariant(state, value);
-				if (err != nullptr) {
+				if (!err.is_null()) {
 					return err;
 				}
 
@@ -334,10 +334,10 @@ LuaError *LuaState::pushVariant(lua_State *state, Variant var) {
 
 			// If the type being pushed is a lua error, Raise a error
 #ifndef LAPI_GDEXTENSION
-			if (LuaError *err = Object::cast_to<LuaError>(var.operator Object *()); err != nullptr) {
+			if (Ref<LuaError> err = Object::cast_to<LuaError>(var.operator Object *()); !err.is_null()) {
 #else
 			// blame this on https://github.com/godotengine/godot-cpp/issues/995
-			if (LuaError *err = dynamic_cast<LuaError *>(var.operator Object *()); err != nullptr) {
+			if (Ref<LuaError> err = dynamic_cast<LuaError *>(var.operator Object *()); !err.is_null()) {
 #endif
 				lua_pushstring(state, err->getMessage().ascii().get_data());
 				lua_error(state);
@@ -398,15 +398,15 @@ LuaError *LuaState::pushVariant(lua_State *state, Variant var) {
 			if (callable.is_custom()) {
 				// If the type being pushed is a lua function ref, push the ref instead.
 #ifndef LAPI_GDEXTENSION
-				LuaAPI *callObj = Object::cast_to<LuaAPI>(callable.get_object());
+				Ref<LuaAPI> callObj = Object::cast_to<LuaAPI>(callable.get_object());
 #else
-				LuaAPI *callObj = dynamic_cast<LuaAPI *>(callable.get_object());
+				Ref<LuaAPI> callObj = dynamic_cast<LuaAPI *>(callable.get_object());
 #endif
-				if (callObj != nullptr && (String)callable.get_method() == "call_function_ref") {
+				if (callObj.is_valid() && (String)callable.get_method() == "call_function_ref") {
 					Array argBinds = callable.get_bound_arguments();
 					if (argBinds.size() == 1) {
-						lua_rawgeti(state, LUA_REGISTRYINDEX, (int)argBinds[0]);
 						lua_State *refState = callObj->getState();
+						lua_rawgeti(refState, LUA_REGISTRYINDEX, (int)argBinds[0]);
 						if (refState != state) {
 							lua_xmove(refState, state, 1);
 						}
@@ -513,7 +513,7 @@ Variant LuaState::getVariant(lua_State *state, int index) {
 }
 
 // Assumes there is a error in the top of the stack. Pops it.
-LuaError *LuaState::handleError(lua_State *state, int lua_error) {
+Ref<LuaError> LuaState::handleError(lua_State *state, int lua_error) {
 	String msg;
 	switch (lua_error) {
 		case LUA_ERRRUN: {
@@ -551,7 +551,7 @@ LuaError *LuaState::handleError(lua_State *state, int lua_error) {
 
 #ifndef LAPI_GDEXTENSION
 // for handling callable errors.
-LuaError *LuaState::handleError(const StringName &func, Callable::CallError error, const Variant **p_arguments, int argc) {
+Ref<LuaError> LuaState::handleError(const StringName &func, Callable::CallError error, const Variant **p_arguments, int argc) {
 	switch (error.error) {
 		case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT: {
 			return LuaError::newError(
@@ -597,7 +597,7 @@ LuaError *LuaState::handleError(const StringName &func, Callable::CallError erro
 
 #else
 
-LuaError *LuaState::handleError(const StringName &func, GDExtensionCallError error, const Variant **p_arguments, int argc) {
+Ref<LuaError> LuaState::handleError(const StringName &func, GDExtensionCallError error, const Variant **p_arguments, int argc) {
 	switch (error.error) {
 		case GDEXTENSION_CALL_ERROR_INVALID_ARGUMENT: {
 			return LuaError::newError(
@@ -708,7 +708,7 @@ int LuaState::luaCallableCall(lua_State *state) {
 	for (int i = 0; i < argc; i++) {
 		args[i] = LuaState::getVariant(state, index++);
 		if (args[i].get_type() != Variant::Type::OBJECT) {
-			if (LuaError *err = Object::cast_to<LuaError>(args[i].operator Object *()); err != nullptr) {
+			if (Ref<LuaError> err = Object::cast_to<LuaError>(args[i].operator Object *()); !err.is_null()) {
 				lua_pushstring(state, err->getMessage().ascii().get_data());
 				lua_error(state);
 				return 0;
@@ -724,7 +724,7 @@ int LuaState::luaCallableCall(lua_State *state) {
 	Callable::CallError error;
 	callable.callp(p_args, argc, returned, error);
 	if (error.error != error.CALL_OK) {
-		LuaError *err = LuaState::handleError(callable.get_method(), error, p_args, argc);
+		Ref<LuaError> err = LuaState::handleError(callable.get_method(), error, p_args, argc);
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return 0;
@@ -735,8 +735,8 @@ int LuaState::luaCallableCall(lua_State *state) {
 		return lua_yield(state, lua_gettop(state));
 	}
 
-	LuaError *err = LuaState::pushVariant(state, returned);
-	if (err != nullptr) {
+	Ref<LuaError> err = LuaState::pushVariant(state, returned);
+	if (!err.is_null()) {
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return 0;
@@ -763,7 +763,7 @@ int LuaState::luaCallableCall(lua_State *state) {
 	for (int i = 0; i < argc; i++) {
 		Variant var = LuaState::getVariant(state, index++);
 		if (var.get_type() == Variant::Type::OBJECT) {
-			if (LuaError *err = dynamic_cast<LuaError *>(var.operator Object *()); err != nullptr) {
+			if (Ref<LuaError> err = dynamic_cast<LuaError *>(var.operator Object *()); !err.is_null()) {
 				lua_pushstring(state, err->getMessage().ascii().get_data());
 				lua_error(state);
 				return 0;
@@ -779,8 +779,8 @@ int LuaState::luaCallableCall(lua_State *state) {
 		return lua_yield(state, lua_gettop(state));
 	}
 
-	LuaError *err = LuaState::pushVariant(state, returned);
-	if (err != nullptr) {
+	Ref<LuaError> err = LuaState::pushVariant(state, returned);
+	if (!err.is_null()) {
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return 0;
@@ -818,7 +818,7 @@ int LuaState::luaUserdataFuncCall(lua_State *state) {
 	Callable::CallError error;
 	obj->callp(fName.ascii().get_data(), p_args, argc, returned, error);
 	if (error.error != error.CALL_OK) {
-		LuaError *err = LuaState::handleError(fName, error, p_args, argc);
+		Ref<LuaError> err = LuaState::handleError(fName, error, p_args, argc);
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return 0;
@@ -827,7 +827,7 @@ int LuaState::luaUserdataFuncCall(lua_State *state) {
 	GDExtensionCallError error;
 	obj->callp(fName.ascii().get_data(), p_args, argc, returned, error);
 	if (error.error != GDEXTENSION_CALL_OK) {
-		LuaError *err = LuaState::handleError(fName, error, p_args, argc);
+		Ref<LuaError> err = LuaState::handleError(fName, error, p_args, argc);
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return 0;
@@ -876,7 +876,7 @@ void LuaState::luaHook(lua_State *state, lua_Debug *ar) {
 	Callable::CallError error;
 	hook.callp(p_args, argc, returned, error);
 	if (error.error != error.CALL_OK) {
-		LuaError *err = LuaState::handleError(hook.get_method(), error, p_args, argc);
+		Ref<LuaError> err = LuaState::handleError(hook.get_method(), error, p_args, argc);
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 		return;
@@ -885,19 +885,13 @@ void LuaState::luaHook(lua_State *state, lua_Debug *ar) {
 	if (returned.get_type() == Variant::NIL) {
 		return;
 	}
-
-	LuaError *err = LuaState::pushVariant(state, returned);
-	if (err != nullptr) {
-		lua_pushstring(state, err->getMessage().ascii().get_data());
-		lua_error(state);
-	}
 #else
 	Variant returned = hook.callv(args);
+#endif
 
-	LuaError *err = LuaState::pushVariant(state, returned);
-	if (err != nullptr) {
+	Ref<LuaError> err = LuaState::pushVariant(state, returned);
+	if (!err.is_null()) {
 		lua_pushstring(state, err->getMessage().ascii().get_data());
 		lua_error(state);
 	}
-#endif
 }

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -29,18 +29,18 @@ public:
 	Variant pullVariant(String name);
 	Variant callFunction(String functionName, Array args);
 
-	LuaError *pushVariant(Variant var) const;
-	LuaError *pushGlobalVariant(String name, Variant var);
-	LuaError *handleError(int lua_error) const;
+	Ref<LuaError> pushVariant(Variant var) const;
+	Ref<LuaError> pushGlobalVariant(String name, Variant var);
+	Ref<LuaError> handleError(int lua_error) const;
 
 	static LuaAPI *getAPI(lua_State *state);
 
-	static LuaError *pushVariant(lua_State *state, Variant var);
-	static LuaError *handleError(lua_State *state, int lua_error);
+	static Ref<LuaError> pushVariant(lua_State *state, Variant var);
+	static Ref<LuaError> handleError(lua_State *state, int lua_error);
 #ifndef LAPI_GDEXTENSION
-	static LuaError *handleError(const StringName &func, Callable::CallError error, const Variant **p_arguments, int argc);
+	static Ref<LuaError> handleError(const StringName &func, Callable::CallError error, const Variant **p_arguments, int argc);
 #else
-	static LuaError *handleError(const StringName &func, GDExtensionCallError error, const Variant **p_arguments, int argc);
+	static Ref<LuaError> handleError(const StringName &func, GDExtensionCallError error, const Variant **p_arguments, int argc);
 #endif
 	static Variant getVariant(lua_State *state, int index);
 

--- a/src/metatables.cpp
+++ b/src/metatables.cpp
@@ -408,8 +408,8 @@ void LuaState::createObjectMetatable() {
 		}
 
 		if (mt.is_valid()) {
-			LuaError *err = mt->__newindex(arg1, api, arg2, arg3);
-			if (err != nullptr) {
+			Ref<LuaError> err = mt->__newindex(arg1, api, arg2, arg3);
+			if (!err.is_null()) {
 				LuaState::pushVariant(inner_state, err);
 				return 1;
 			}
@@ -450,8 +450,8 @@ void LuaState::createObjectMetatable() {
 		}
 
 		if (mt.is_valid()) {
-			LuaError *err = mt->__gc(arg1, api);
-			if (err != nullptr) {
+			Ref<LuaError> err = mt->__gc(arg1, api);
+			if (!err.is_null()) {
 				LuaState::pushVariant(inner_state, err);
 			}
 		}


### PR DESCRIPTION
## What's changed
- Fixed error return types to allow mono bindings to work hopefully
- __index and __newindex now do not force the String type as the index, as this could in theory be any type.
- LuaAPI's memory usage, and limit are not uint64's rather then just a signed int32. 
- Other various code base cleanup tasks