### PR TITLE
Mono actions for release builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -62,6 +62,37 @@ jobs:
             artifact-name: export-templates
             build-options: "target=template_debug arch=x86_32"
             should-run: ${{ inputs.fullbuild }}
+
+          - name: Linux Editor Mono (target=editor,module_mono_enabled=yes)
+            cache-name: linux-editor-mono
+            artifact-name: linux-editor-mono
+            build-options: "target=editor module_mono_enabled=yes arch=x86_64"
+            should-run: true # verify mono builds
+          
+          - name: Linux Template Mono (target=template_release,module_mono_enabled=yes,arch=x86_64)
+            cache-name: linux-template-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_release module_mono_enabled=yes arch=x86_64"
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: Linux Template Debug Mono (target=template_debug,module_mono_enabled=yes,arch=x86_64)
+            cache-name: linux-template-debug-mono
+            artifact-name: export-templates
+            build-options: "target=template_debug module_mono_enabled=yes arch=x86_64"
+            should-run: ${{ inputs.fullbuild }}
+          
+          - name: Linux Template Mono (target=template_release,module_mono_enabled=yes,arch=x86_32)
+            cache-name: linux-template-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_release module_mono_enabled=yes arch=x86_32"
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: Linux Template Debug Mono (target=template_debug,module_mono_enabled=yes,arch=x86_32)
+            cache-name: linux-template-debug-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_debug module_mono_enabled=yes arch=x86_32"
+            should-run: ${{ inputs.fullbuild }}
+
         exclude:
           - {opts: {should-run: false}}
 
@@ -98,6 +129,12 @@ jobs:
           cd buildroot
           ./relocate-sdk.sh
 
+      - name: Install .NET SDK 6.0 (Mono)
+        if: ${{ contains(matrix.opts.build-options, 'module_mono_enabled=yes') }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+
       - name: Load .scons_cache directory
         uses: actions/cache@v2
         with:
@@ -133,6 +170,12 @@ jobs:
           strip scripts/godot/bin/godot.*
           chmod +x scripts/godot/bin/godot.*
 
+      - name: Generate Mono Glue
+        if: ${{ matrix.opts.cache-name == 'linux-editor-mono' }}
+        run: |
+          cd scripts/godot
+          bin/godot.linuxbsd.editor.x86_64.luaAPI.mono --headless --generate-mono-glue bin
+
       - name: Prepare templates
         if: matrix.opts.artifact-name == 'export-templates'
         run: |
@@ -143,6 +186,10 @@ jobs:
           mv scripts/godot/bin/godot.linuxbsd.template_release.x86_32.luaAPI scripts/godot/templates/linux_release.x32_64 || true
           mv scripts/godot/bin/godot.linuxbsd.template_debug.x86_32.luaAPI scripts/godot/templates/linux_debug.x86_32 || true
 
+          mv scripts/godot/bin/godot.linuxbsd.template_release.x86_64.luaAPI.mono scripts/godot/templates/linux_release.x86_64 || true
+          mv scripts/godot/bin/godot.linuxbsd.template_debug.x86_64.luaAPI.mono scripts/godot/templates/linux_debug.x86_64 || true
+          mv scripts/godot/bin/godot.linuxbsd.template_release.x86_32.luaAPI.mono scripts/godot/templates/linux_release.x32_64 || true
+          mv scripts/godot/bin/godot.linuxbsd.template_debug.x86_32.luaAPI.mono scripts/godot/templates/linux_debug.x86_32  || true
           
           rm -rf scripts/godot/bin/*
           mv scripts/godot/templates scripts/godot/bin/

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -32,7 +32,7 @@ jobs:
             artifact-name: macos-editor-bins
             build-options: "target=editor arch=x86_64"
             should-run: true
-          
+
           - name: macOS Editor (target=editor,arch=arm64)
             cache-name: macos-editor-arm64
             artifact-name: macos-editor-bins
@@ -74,6 +74,44 @@ jobs:
             artifact-name: macos-templates
             build-options: "arch=arm64 target=template_release"
             should-run: ${{ inputs.fullbuild }}
+
+          - name: macOS Editor Mono (target=editor,module_mono_enabled=yes,arch=x86_64)
+            cache-name: macos-editor-mono-x86
+            artifact-name: macos-editor-mono-bins
+            build-options: "target=editor module_mono_enabled=yes arch=x86_64"
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: macOS Editor Mono (target=editor,module_mono_enabled=yes,arch=arm64)
+            cache-name: macos-editor-mono-arm64
+            artifact-name: macos-editor-mono-bins
+            build-options: "target=editor module_mono_enabled=yes arch=arm64"
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: macOS Template Mono (target=template_debug,module_mono_enabled=yes,arch=x86_64)
+            cache-name: macos-template-debug-mono-x86
+            artifact-name: macos-templates-mono
+            build-options: "arch=x86_64 module_mono_enabled=yes target=template_debug"
+            should-run: ${{ inputs.fullbuild }}
+          
+          - name: macOS Template Mono (target=template_debug,module_mono_enabled=yes,arch=arm64)
+            cache-name: macos-template-debug-mono-arm
+            artifact-name: macos-templates-mono
+            build-options: "arch=arm64 module_mono_enabled=yes target=template_debug"
+            should-run: ${{ inputs.fullbuild }}
+          
+          - name: macOS Template Mono (target=template_release,module_mono_enabled=yes,arch=x86_64)
+            cache-name: macos-template-release-mono-x86
+            artifact-name: macos-templates-mono
+            build-options: "arch=x86_64 module_mono_enabled=yes target=template_release"
+            should-run: ${{ inputs.fullbuild }}
+          
+          - name: macOS Template Mono (target=template_release,module_mono_enabled=yes,arch=arm64)
+            cache-name: macos-template-release-mono-arm
+            artifact-name: macos-templates-mono
+            build-options: "arch=arm64 module_mono_enabled=yes target=template_release"
+            should-run: ${{ inputs.fullbuild }}
+
+
         exclude:
           - {opts: {should-run: false}}
 
@@ -85,6 +123,12 @@ jobs:
       - name: Setup Vulkan SDK
         run: |
           sh scripts/install_vulkan_sdk_macos.sh
+      
+      - name: Install .NET SDK 6.0 (Mono)
+        if: ${{ contains(matrix.opts.build-options, 'module_mono_enabled=yes') }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
 
       - name: Load .scons_cache directory
         uses: actions/cache@v2

--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -22,6 +22,14 @@ jobs:
             artifact-name: macos-editor-bins
             final-artifact-name: macos-editor
             should-run: true
+          
+          - name: macOS Mono Editor
+            cache-name: macos-editor-mono
+            editor: true
+            mono: true
+            artifact-name: macos-editor-mono-bins
+            final-artifact-name: macos-editor-mono
+            should-run: ${{ inputs.fullbuild }}
 
           - name: macOS Editor LuaJIT
             editor: true
@@ -33,6 +41,13 @@ jobs:
             template: true
             artifact-name: macos-templates
             final-artifact-name: export-templates
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: MacOS Templates Mono
+            template: true
+            mono: true
+            artifact-name: macos-templates-mono
+            final-artifact-name: export-templates-mono
             should-run: ${{ inputs.fullbuild }}
         exclude:
           - {opts: {should-run: false}}
@@ -61,24 +76,62 @@ jobs:
 
       - name: Make universal binaries and bundle (editor)
         working-directory: ./scripts/godot
-        if: ${{ matrix.opts.editor }}
+        if: ${{ matrix.opts.editor && !matrix.opts.mono }}
         run: |
           lipo -create bin/godot.macos.editor.x86_64.luaAPI bin/godot.macos.editor.arm64.luaAPI -output bin/godot.macos.editor.universal.luaAPI
           strip bin/godot.macos.editor.universal.luaAPI
           rm -rf bin/godot.macos.editor.x86_64.luaAPI bin/godot.macos.editor.arm64.luaAPI
           cp -r misc/dist/macos_tools.app Godot.app
           mkdir Godot.app/Contents/MacOS
-          cp bin/godot.macos.editor.universal.luaAPI Godot.app/Contents/MacOS/Godot
+          mv bin/godot.macos.editor.universal.luaAPI Godot.app/Contents/MacOS/Godot
           chmod +x Godot.app/Contents/MacOS/Godot
+          mv Godot.app bun/
+          cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/scripts/godot/bin/
+      
+      - name: Make universal binaries and bundle (mono editor)
+        working-directory: ./scripts/godot
+        if: ${{ matrix.opts.editor && matrix.opts.mono }}
+        run: |
+          lipo -create bin/godot.macos.editor.x86_64.luaAPI.mono bin/godot.macos.editor.arm64.luaAPI.mono -output bin/godot.macos.editor.universal.luaAPI.mono
+          strip bin/godot.macos.editor.universal.luaAPI.mono
+          rm -rf bin/godot.macos.editor.x86_64.luaAPI.mono bin/godot.macos.editor.arm64.luaAPI.mono
+
+          chmod +x bin/godot.macos.editor.universal.luaAPI.mono
+
+          bin/godot.macos.editor.universal.luaAPI.mono --headless --generate-mono-glue bin
+
+          cp -r misc/dist/macos_tools.app Godot.app
+          mkdir Godot.app/Contents/MacOS
+          mv bin/godot.macos.editor.universal.luaAPI Godot.app/Contents/MacOS/Godot
+          mv Godot.app bun/
           cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/scripts/godot/bin/
 
       - name: Make universal binaries and bundle (template)
         working-directory: ./scripts/godot
-        if: ${{ matrix.opts.template }}
+        if: ${{ matrix.opts.template && !matrix.opts.mono}}
         run: |
           lipo -create bin/godot.macos.template_debug.x86_64.luaAPI bin/godot.macos.template_debug.arm64.luaAPI -output bin/godot.macos.template_debug.universal.luaAPI
           lipo -create bin/godot.macos.template_release.x86_64.luaAPI bin/godot.macos.template_release.arm64.luaAPI -output bin/godot.macos.template_release.universal.luaAPI
           rm -rf bin/godot.macos.template_debug.x86_64.luaAPI bin/godot.macos.template_debug.arm64.luaAPI bin/godot.macos.template_release.x86_64.luaAPI bin/godot.macos.template_release.arm64.luaAPI
+          strip bin/godot.*
+          cp -r misc/dist/macos_template.app macos_template.app
+          mkdir macos_template.app/Contents/MacOS
+          cp bin/godot.macos.template_debug.universal.luaAPI macos_template.app/Contents/MacOS/godot_macos_debug.universal.luaAPI
+          cp bin/godot.macos.template_release.universal.luaAPI macos_template.app/Contents/MacOS/godot_macos_release.universal.luaAPI
+          chmod +x macos_template.app/Contents/MacOS/godot_macos_debug.universal.luaAPI
+          chmod +x macos_template.app/Contents/MacOS/godot_macos_release.universal.luaAPI
+          zip -r macos.zip macos_template.app
+          rm -rf bin/*
+          mkdir bin/templates
+          mv macos.zip bin/templates/macos.zip
+      
+      - name: Make universal binaries and bundle (mono template)
+        working-directory: ./scripts/godot
+        if: ${{ matrix.opts.template && !matrix.opts.mono}}
+        run: |
+          lipo -create bin/godot.macos.template_debug.x86_64.luaAPI.mono bin/godot.macos.template_debug.arm64.luaAPI.mono -output bin/godot.macos.template_debug.universal.luaAPI
+          lipo -create bin/godot.macos.template_release.x86_64.luaAPI.mono bin/godot.macos.template_release.arm64.luaAPI.mono -output bin/godot.macos.template_release.universal.luaAPI
+          rm -rf bin/godot.macos.template_debug.x86_64.luaAPI.mono bin/godot.macos.template_debug.arm64.luaAPI.mono bin/godot.macos.template_release.x86_64.luaAPI.mono bin/godot.macos.template_release.arm64.luaAPI.mono
           strip bin/godot.*
           cp -r misc/dist/macos_template.app macos_template.app
           mkdir macos_template.app/Contents/MacOS

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -127,8 +127,16 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/bin/templates
           echo ${{ env.GODOT_VERSION }}.stable > ${{ github.workspace }}/bin/templates/version.txt
+
+          mkdir -p ${{ github.workspace }}/bin-mono/templates
+          echo ${{ env.GODOT_VERSION }}.stable.mono > ${{ github.workspace }}/bin-mono/templates/version.txt
       - name: Upload version file
         uses: actions/upload-artifact@v2
         with:
           name: export-templates
           path: ${{ github.workspace }}/bin/*
+      - name: Upload Mono version file
+        uses: actions/upload-artifact@v2
+        with:
+          name: export-templates-mono
+          path: ${{ github.workspace }}/bin-mono/*

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -67,6 +67,42 @@ jobs:
             build-options: "target=template_debug arch=x86_32"
             runner: "ubuntu-20.04"
             should-run: ${{ inputs.fullbuild }}
+
+          - name: Windows Editor Mono (target=editor,module_mono_enabled=yes)
+            cache-name: windows-editor-mono
+            artifact-name: windows-editor-mono
+            build-options: "target=editor module_mono_enabled=yes"
+            runner: "ubuntu-20.04"
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: Windows Template Mono (target=template_release,module_mono_enabled=yes,arch=x86_64)
+            cache-name: windows-template-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_release module_mono_enabled=yes arch=x86_64"
+            runner: "ubuntu-20.04"
+            should-run: ${{ inputs.fullbuild }}
+          
+          - name: Windows Template Debug Mono (target=template_debug,module_mono_enabled=yes,arch=x86_64)
+            cache-name: windows-template-debug-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_debug module_mono_enabled=yes arch=x86_64"
+            runner: "ubuntu-20.04"
+            should-run: ${{ inputs.fullbuild }}
+
+          - name: Windows Template Mono (target=template_release,module_mono_enabled=yes,arch=x86_32)
+            cache-name: windows-template-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_release module_mono_enabled=yes arch=x86_32"
+            runner: "ubuntu-20.04"
+            should-run: ${{ inputs.fullbuild }}
+          
+          - name: Windows Template Debug Mono (target=template_debug,module_mono_enabled=yes,arch=x86_32)
+            cache-name: windows-template-debug-mono
+            artifact-name: export-templates-mono
+            build-options: "target=template_debug module_mono_enabled=yes arch=x86_32"
+            runner: "ubuntu-20.04"
+            should-run: ${{ inputs.fullbuild }}
+
         exclude:
           - {opts: {should-run: false}}
 
@@ -99,6 +135,22 @@ jobs:
           sudo update-alternatives --set i686-w64-mingw32-gcc /usr/bin/i686-w64-mingw32-gcc-posix
           sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
 
+      - name: Install .NET SDK 6.0 (Mono)
+        if: ${{ contains(matrix.opts.build-options, 'module_mono_enabled=yes') }}
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '6.0.x'
+      
+      - name: Install Wine (Mono)
+        if: matrix.opts.artifact-name == 'windows-editor-mono'
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install wine
+
+          wine --version
+          
+
       - name: Set up Python 3.x
         uses: actions/setup-python@v2
         with:
@@ -120,7 +172,6 @@ jobs:
           python -m pip install scons
           python --version
           scons --version
-
       
       - name: Compilation
         working-directory: ./scripts
@@ -128,7 +179,7 @@ jobs:
           SCONS_CACHE: ${{github.workspace}}/.scons_cache/
         run: |
           scons platform=windows ${{ matrix.opts.build-options }} ${{ env.SCONSFLAGS }}
-          
+        
       - name: Prepare artifact (Windows)
         if: matrix.opts.runner == 'windows-latest'
         shell: bash
@@ -142,8 +193,15 @@ jobs:
           rm -rf scripts/godot/bin/{*.exp,*.lib,*.pdb}
           strip scripts/godot/bin/*.exe
 
+      - name: Generate Mono Glue
+        if: matrix.opts.artifact-name == 'windows-editor-mono'
+        shell: bash
+        run: |
+          cd scripts/godot=
+          wine bin/godot.windows.editor.x86_64.luaAPI.mono.exe --headless --generate-mono-glue bin
+
       - name: Prepare templates
-        if: matrix.opts.artifact-name == 'export-templates'
+        if: ${{ contains(matrix.opts.artifact-name, 'export-templates') }}
         shell: bash
         run: |
           mkdir -p scripts/godot/templates
@@ -157,6 +215,16 @@ jobs:
           mv scripts/godot/bin/godot.windows.template_debug.x86_64.luaAPI.console.exe scripts/godot/templates/windows_debug_x86_64_console.exe || true
           mv scripts/godot/bin/godot.windows.template_release.x86_32.luaAPI.console.exe scripts/godot/templates/windows_release_x86_32_console.exe || true
           mv scripts/godot/bin/godot.windows.template_debug.x86_32.luaAPI.console.exe scripts/godot/templates/windows_debug_x86_32_console.exe || true
+
+          mv scripts/godot/bin/godot.windows.template_release.x86_64.luaAPI.mono.exe scripts/godot/templates/windows_release_x86_64.exe || true
+          mv scripts/godot/bin/godot.windows.template_debug.x86_64.luaAPI.mono.exe scripts/godot/templates/windows_debug_x86_64.exe || true
+          mv scripts/godot/bin/godot.windows.template_release.x86_32.luaAPI.mono.exe scripts/godot/templates/windows_release_x86_32.exe || true
+          mv scripts/godot/bin/godot.windows.template_debug.x86_32.luaAPI.mono.exe scripts/godot/templates/windows_debug_x86_32.exe || true
+          
+          mv scripts/godot/bin/godot.windows.template_release.x86_64.luaAPI.mono.console.exe scripts/godot/templates/windows_release_x86_64_console.exe || true
+          mv scripts/godot/bin/godot.windows.template_debug.x86_64.luaAPI.mono.console.exe scripts/godot/templates/windows_debug_x86_64_console.exe || true
+          mv scripts/godot/bin/godot.windows.template_release.x86_32.luaAPI.mono.console.exe scripts/godot/templates/windows_release_x86_32_console.exe || true
+          mv scripts/godot/bin/godot.windows.template_debug.x86_32.luaAPI.mono.console.exe scripts/godot/templates/windows_debug_x86_32_console.exe || true
 
           
           rm -rf scripts/godot/bin/*


### PR DESCRIPTION
The need has been expressed by multiple people for c# support. Well while technically there is no reason c# should not work with this module. There is known to be several issues with it overall. Hopefully these are issues that can be fixed with time. But this will at least allow people to see what works and what does not. 

This PR also fixes the formatting of the macOS editor release builds