### PR TITLE
Add FFI & UTF8

### DIFF
--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -177,7 +177,7 @@ Ref<LuaError> LuaAPI::doFile(String fileName) {
 		path = file->get_path_absolute();
 	}
 
-	int ret = luaL_loadfile(lState, path.ascii().get_data());
+	int ret = luaL_loadfile(lState, path.utf8().get_data());
 	if (ret != LUA_OK) {
 		return state.handleError(ret);
 	}
@@ -192,7 +192,7 @@ Ref<LuaError> LuaAPI::doFile(String fileName) {
 Ref<LuaError> LuaAPI::doString(String code) {
 	// push the error handler onto the stack
 	lua_pushcfunction(lState, LuaState::luaErrorHandler);
-	int ret = luaL_loadstring(lState, code.ascii().get_data());
+	int ret = luaL_loadstring(lState, code.utf8().get_data());
 	if (ret != LUA_OK) {
 		return state.handleError(ret);
 	}

--- a/src/classes/luaCoroutine.cpp
+++ b/src/classes/luaCoroutine.cpp
@@ -100,7 +100,7 @@ Ref<LuaError> LuaCoroutine::setRegistryValue(String name, Variant var) {
 // loads a string into the threads state
 Ref<LuaError> LuaCoroutine::loadString(String code) {
 	done = false;
-	int ret = luaL_loadstring(tState, code.ascii().get_data());
+	int ret = luaL_loadstring(tState, code.utf8().get_data());
 	if (ret != LUA_OK) {
 		return state.handleError(ret);
 	}
@@ -124,7 +124,7 @@ Ref<LuaError> LuaCoroutine::loadFile(String fileName) {
 #endif
 
 	String path = file->get_path_absolute();
-	int ret = luaL_loadfile(tState, path.ascii().get_data());
+	int ret = luaL_loadfile(tState, path.utf8().get_data());
 	if (ret != LUA_OK) {
 		return state.handleError(ret);
 	}


### PR DESCRIPTION
This PR adds support for UTF8 encoded strings. Part of the way this was implemented was we no longer assume ascii, rather we assume UTF8. I don't think any issues should come from this but we will see. In the future we might need to look into supporting both some how. This makes this PR 1/2 to fix #152, PR number 2 should come shortly for the v1.x release of this module.

![image](https://github.com/WeaselGames/godot_luaAPI/assets/7241029/18fdaf48-76bd-4d27-aa58-051915a67f67)


This PR also adds the FFI library to luaJIT builds which resolves #159 

