### PR TITLE
Fix mono export template builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -77,7 +77,7 @@ jobs:
 
           - name: Linux Template Debug Mono (target=template_debug,module_mono_enabled=yes,arch=x86_64)
             cache-name: linux-template-debug-mono
-            artifact-name: export-templates
+            artifact-name: export-templates-mono
             build-options: "target=template_debug module_mono_enabled=yes arch=x86_64"
             should-run: ${{ inputs.fullbuild }}
           

--- a/.github/workflows/macos-package.yml
+++ b/.github/workflows/macos-package.yml
@@ -110,6 +110,8 @@ jobs:
           cp -r misc/dist/macos_tools.app Godot.app
           mkdir Godot.app/Contents/MacOS
           mv bin/godot.macos.editor.universal.luaAPI.mono Godot.app/Contents/MacOS/Godot
+          mkdir Godot.app/Contents/Resources
+          mv bin/GodotSharp Godot.app/Contents/Resources/
           mv Godot.app bin/
           cp -n '${{ github.workspace }}/README.md' '${{ github.workspace }}/LICENSE' ${{ github.workspace }}/scripts/godot/bin/
 


### PR DESCRIPTION
64 bit debug templates were being sent to the wrong artifact.

Should resolve the issue brought up in https://github.com/WeaselGames/godot_luaAPI/pull/165#issuecomment-1748023960