### PR TITLE
Add LuaFuntionRef type

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - "*"
     paths-ignore:
-      - "README.md"
+      - "**/*.md"
       - "LICENSE"
       - "**/*.png"
       - ".github/ISSUE_TEMPLATE/*"
@@ -16,7 +16,7 @@ on:
     branches:
       - "main"
     paths-ignore:
-      - "**/README.md"
+      - "**/*.md"
       - "**/*.png"
       - "**/LICENSE"
       - ".github/ISSUE_TEMPLATE/*"

--- a/config.py
+++ b/config.py
@@ -26,6 +26,7 @@ def get_doc_classes():
         "LuaError",
         "LuaTuple",
         "LuaCallableExtra",
+        "LuaFunctionRef",
         "LuaObjectMetatable",
         "LuaDefaultObjectMetatable",
     ]

--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -7,7 +7,7 @@
 		This class represents a lua state and allows you to interact with lua at runtime. You can load files and strings code. Push Callable's as lua functions. And push any Variant as a lua variable.
 	</description>
 	<tutorials>
-	</tutorials>w
+	</tutorials>
 	<methods>
 		<method name="new_coroutine">
 			<return type="LuaCoroutine" />
@@ -131,6 +131,9 @@
 		<member name="memory_limit" type="int" setter="set_memory_limit" getter="get_memory_limit" default="0">
 			Sets the memory limit for the state in bytes. If the limit is 0, there is no limit.
 		</member>
+		<member name="use_callables" type="bool" setter="set_use_callables" getter="get_use_callables" default="true">
+			When true, Lua functions passed to Godot will use the LuaCallable type. This type is a CallableCustom which has issues currently with GDExtension and C#
+			When false, Lua functions passed to Godot will use the LuaFunctionRef type. This type is a RefCounted which behaves the same as a LuaCallable. But uses Inoke instead of Call.
 	</members>
 	<constants>
 		<constant name="GC_STOP" value="1" enum="HookMask">

--- a/doc_classes/LuaFunctionRef.xml
+++ b/doc_classes/LuaFunctionRef.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="LuaFunctionRef" inherits="RefCounted" version="4.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Lua Function Reference.
+	</brief_description>
+	<description>
+		Reference to a Lua function. This class is used to pass Lua functions to Godot.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="inoke">
+			<return type="Variant" />
+			<param index="0" name="Arguments" type="Array" />
+			<description>
+				Invoke the Lua function being referenced.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -3,6 +3,7 @@
 #include "src/classes/luaCallableExtra.h"
 #include "src/classes/luaCoroutine.h"
 #include "src/classes/luaError.h"
+#include "src/classes/luaFunctionRef.h"
 #include "src/classes/luaObjectMetatable.h"
 #include "src/classes/luaTuple.h"
 
@@ -19,6 +20,7 @@ void initialize_luaAPI_module(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<LuaCallableExtra>();
 	ClassDB::register_class<LuaCoroutine>();
 	ClassDB::register_class<LuaError>();
+	ClassDB::register_class<LuaFunctionRef>();
 	ClassDB::register_class<LuaObjectMetatable>();
 	ClassDB::register_class<LuaDefaultObjectMetatable>();
 	ClassDB::register_class<LuaTuple>();

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -45,12 +45,16 @@ void LuaAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("new_coroutine"), &LuaAPI::newCoroutine);
 	ClassDB::bind_method(D_METHOD("get_running_coroutine"), &LuaAPI::getRunningCoroutine);
 
+	ClassDB::bind_method(D_METHOD("set_use_callables", "value"), &LuaAPI::setUseCallables);
+	ClassDB::bind_method(D_METHOD("get_use_callables"), &LuaAPI::getUseCallables);
+
 	ClassDB::bind_method(D_METHOD("set_object_metatable", "value"), &LuaAPI::setObjectMetatable);
 	ClassDB::bind_method(D_METHOD("get_object_metatable"), &LuaAPI::getObjectMetatable);
 
 	ClassDB::bind_method(D_METHOD("set_memory_limit", "limit"), &LuaAPI::setMemoryLimit);
 	ClassDB::bind_method(D_METHOD("get_memory_limit"), &LuaAPI::getMemoryLimit);
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_callables"), "set_use_callables", "get_use_callables");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "object_metatable"), "set_object_metatable", "get_object_metatable");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "memory_limit"), "set_memory_limit", "get_memory_limit");
 
@@ -80,6 +84,14 @@ void LuaAPI::setHook(Callable hook, int mask, int count) {
 
 int LuaAPI::configureGC(int what, int data) {
 	return lua_gc(lState, what, data);
+}
+
+void LuaAPI::setUseCallables(bool value) {
+	useCallables = value;
+}
+
+bool LuaAPI::getUseCallables() const {
+	return useCallables;
 }
 
 void LuaAPI::setObjectMetatable(Ref<LuaObjectMetatable> value) {

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -33,6 +33,9 @@ public:
 	void bindLibraries(Array libs);
 	void setHook(Callable hook, int mask, int count);
 
+	void setUseCallables(bool value);
+	bool getUseCallables() const;
+
 	void setObjectMetatable(Ref<LuaObjectMetatable> value);
 	Ref<LuaObjectMetatable> getObjectMetatable() const;
 
@@ -82,6 +85,8 @@ public:
 	};
 
 private:
+	bool useCallables = true;
+
 	LuaState state;
 	lua_State *lState = nullptr;
 

--- a/src/classes/luaFunctionRef.cpp
+++ b/src/classes/luaFunctionRef.cpp
@@ -1,0 +1,46 @@
+#include "luaFunctionRef.h"
+
+#include <luaState.h>
+
+void LuaFunctionRef::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("invoke", "args"), &LuaFunctionRef::invoke);
+}
+
+LuaFunctionRef::LuaFunctionRef() {
+	L = nullptr;
+	ref = LUA_NOREF;
+}
+
+LuaFunctionRef::~LuaFunctionRef() {
+	luaL_unref(L, LUA_REGISTRYINDEX, ref);
+}
+
+void LuaFunctionRef::setLuaState(lua_State *state) {
+	L = state;
+}
+
+void LuaFunctionRef::setRef(int ref) {
+	this->ref = ref;
+}
+
+Variant LuaFunctionRef::invoke(Array args) {
+	lua_pushcfunction(L, LuaState::luaErrorHandler);
+	lua_rawgeti(L, LUA_REGISTRYINDEX, ref);
+
+	for (int i = 0; i < args.size(); i++) {
+		Variant arg = args[i];
+		LuaState::pushVariant(L, arg);
+	}
+
+	int err = lua_pcall(L, args.size(), 1, -2 - args.size());
+	Variant ret;
+	if (err) {
+		ret = LuaState::handleError(L, ret);
+	} else {
+		ret = LuaState::getVariant(L, -1);
+	}
+
+	lua_pop(L, 1);
+
+	return ret;
+}

--- a/src/classes/luaFunctionRef.h
+++ b/src/classes/luaFunctionRef.h
@@ -10,6 +10,10 @@
 
 #include <lua/lua.hpp>
 
+#ifdef LAPI_GDEXTENSION
+using namespace godot;
+#endif
+
 class LuaFunctionRef : public RefCounted {
 	GDCLASS(LuaFunctionRef, RefCounted);
 

--- a/src/classes/luaFunctionRef.h
+++ b/src/classes/luaFunctionRef.h
@@ -1,0 +1,36 @@
+#ifndef LUAFUNCTIONREF_H
+#define LUAFUNCTIONREF_H
+
+#ifndef LAPI_GDEXTENSION
+#include "core/core_bind.h"
+#include "core/object/ref_counted.h"
+#else
+#include <godot_cpp/classes/ref.hpp>
+#endif
+
+#include <lua/lua.hpp>
+
+class LuaFunctionRef : public RefCounted {
+	GDCLASS(LuaFunctionRef, RefCounted);
+
+protected:
+	static void _bind_methods();
+
+public:
+	LuaFunctionRef();
+	~LuaFunctionRef();
+
+	void setLuaState(lua_State *state);
+	void setRef(int ref);
+
+	Variant invoke(Array args);
+
+	inline int getRef() const { return ref; }
+	inline lua_State *getLuaState() const { return L; }
+
+private:
+	lua_State *L;
+	int ref;
+};
+
+#endif


### PR DESCRIPTION
Since C# does not currently support CallableCustoms this PR adds a setting to the LuaAPI class, `luaAPI.use_callables`. It defaults to true. When set to true Lua functions pulled from the Lua state will use the LuaCallable type which is a CallableCustom. For c# or even gdScript to get around #155 it can be set to false to use the LuaFunctionRef type instead which is a RefCounted. It behaves identical to the LuaCallable type but uses an `invoke` method instead.

This is what the README example would look like for c# now

```cs
using Godot;

using System;

public partial class Node2D : Godot.Node2D
{
	private LuaApi lua = new LuaApi();

	public void LuaPrint(string message) {
		GD.Print(message);
	}

	public override void _Ready() {
		lua.UseCallables = false;
		Godot.Collections.Array libraries = new()
        {
            "base",   // Base Lua commands
            "table",  // Table functionality.
            "string" // String Specific functionality.
        };

		lua.BindLibraries(libraries); // Assign the specified libraries to the LuaAPI object.

		// In C#, .PushVariant does not work with Methods, so we use Callable to wrap our function.
		Callable print = new Callable(this, MethodName.LuaPrint);
		// Assign the Callable, so that the API can call our function.
		// Note, the lua function "cs_print" is now callable within Lua script.
		lua.PushVariant("print", print);
		// Assign a Lua Variable named "message" and give it a value.
		lua.PushVariant("message", "Hello lua!");

		LuaError error = lua.DoString(@"
									for i=1,10,1 do
										print(message)
									end
									function get_message()
										return ""Hello gdScript!""
									end
                                  ");

		if (error != null && error.Message != "") {
			GD.Print("An error occurred calling DoString.");
			GD.Print("ERROR %d: %s", error.Type, error.Message);
		}

		var val = lua.PullVariant("get_message");
		if (val.GetType() == typeof(LuaError)) {
			GD.Print("ERROR %d: %s", error.Type, error.Message);
			return;
		}

		LuaFunctionRef get_message = val.As<LuaFunctionRef>();
		if (get_message == null) {
			GD.Print("ERROR: get_message is null.");
			return;
		}

		Godot.Collections.Array Params = new();
		GD.Print(get_message.Invoke(Params));
	}
}
```