### PR TITLE
Support argument passing and return to do_file/string

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -119,10 +119,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
-
-      - name: Setup Vulkan SDK
-        run: |
-          sh scripts/install_vulkan_sdk_macos.sh
       
       - name: Install .NET SDK 6.0 (Mono)
         if: ${{ contains(matrix.opts.build-options, 'module_mono_enabled=yes') }}
@@ -152,6 +148,10 @@ jobs:
           python -m pip install scons
           python --version
           scons --version
+
+      - name: Setup Vulkan SDK
+        run: |
+          sh scripts/install_vulkan_sdk_macos.sh
 
       - name: Compilation
         working-directory: ./scripts

--- a/doc_classes/LuaAPI.xml
+++ b/doc_classes/LuaAPI.xml
@@ -31,19 +31,21 @@
 			</description>
 		</method>
 		<method name="do_file">
-			<return type="LuaError" />
+			<return type="Variant" />
 			<param index="0" name="FilePath" type="String" />
+			<param index="1" name="Args" type="Array" default="[]" />
 			<description>
 				Loads a file with luaL_loadfile() passing its absolute path.
-				Similar to [code].DoString()[/code], this function loads a lua file into the LuaAPI Object and executes it as Lua. [code]FilePath[/code] must be an absolute path, and must exist or an error is returned.
+				Similar to [code].do_string()[/code], this function loads a lua file into the LuaAPI Object and executes it as Lua. [code]FilePath[/code] must be an absolute path, and must exist or an error is returned.
 			</description>
 		</method>
 		<method name="do_string">
-			<return type="LuaError" />
+			<return type="Variant" />
 			<param index="0" name="Code" type="String" />
+			<param index="1" name="Args" type="Array" default="[]" />
 			<description>
 				Loads a string with luaL_loadstring() and executes the top of the stack. Returns any errors.
-				Use [code].DoString()[/code] to execute a lua script or snippet stored within a string variable or a string literal.
+				Use [code].do_string()[/code] to execute a lua script or snippet stored within a string variable or a string literal.
 			</description>
 		</method>
 		<method name="function_exists">

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -48,13 +48,12 @@ public:
 
 	Variant pullVariant(String name);
 	Variant callFunction(String functionName, Array args);
-
+	Variant doFile(String fileName, Array args);
+	Variant doString(String code, Array args);
 	Variant getRegistryValue(String name);
 
 	Ref<LuaError> setRegistryValue(String name, Variant var);
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
-	Ref<LuaError> doFile(String fileName);
-	Ref<LuaError> doString(String code);
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
 
 	Ref<LuaCoroutine> newCoroutine();
@@ -98,7 +97,7 @@ private:
 
 	LuaAllocData luaAllocData;
 
-	Ref<LuaError> execute(int handlerIndex);
+	Variant execute(int argc, int handlerIndex);
 };
 
 VARIANT_ENUM_CAST(LuaAPI::HookMask)


### PR DESCRIPTION
The lack of support for this was just an oversight. do_file and do_string will now take an optional second argument that should be an array of arguments. And now return a Variant instead of a LuaError.

Example
```gdscript
func _ready():
	var lua: LuaAPI = LuaAPI.new()
	lua.bind_libraries(["base", "table", "string"])

	var ret = lua.do_string("""
	local a, b = ...
	print(a, b)
	return a + b
	""", [4, 6])
	if ret is LuaError:
		print("ERROR %d: %s" % [ret.type, ret.message])
		return
	
	print(ret)
```