### PR TITLE
(wip) Add the ability to push a global module to lua, close #197

### DIFF
--- a/lua_libraries/codegen.py
+++ b/lua_libraries/codegen.py
@@ -61,25 +61,35 @@ def code_gen(luaJIT=False):
     if luaJIT:
         luaLibraries_gen_cpp += """
 bool loadLuaLibrary(lua_State *L, String libraryName) {
-	const char *lib_c_str = libraryName.ascii().get_data();
+	char lib_c_str[libraryName.length() + 1];
+	lib_c_str[libraryName.length()] = 0;
+	for(int i = 0; i < libraryName.length(); i++){
+		lib_c_str[i] = libraryName[i];
+	}
+
 	if (luaLibraries[lib_c_str] == nullptr) {
 		return false;
 	}
-	
-    lua_pushcfunction(L, luaLibraries[lib_c_str]);
-    if (libraryName == "base") {
-        lua_pushstring(L, "");
-    } else {
-	    lua_pushstring(L, lib_c_str);
+
+	lua_pushcfunction(L, luaLibraries[lib_c_str]);
+	if (libraryName == "base") {
+		lua_pushstring(L, "");
+	} else {
+		lua_pushstring(L, lib_c_str);
     }
 	lua_call(L, 1, 0);
 	return true;
 }
 """
     else:
-        luaLibraries_gen_cpp += """
+	    luaLibraries_gen_cpp += """
 bool loadLuaLibrary(lua_State *L, String libraryName) {
-	const char *lib_c_str = libraryName.ascii().get_data();
+	char lib_c_str[libraryName.length() + 1];
+	lib_c_str[libraryName.length()] = 0;
+	for(int i = 0; i < libraryName.length(); i++){
+		lib_c_str[i] = libraryName[i];
+	}
+
 	if (luaLibraries[lib_c_str] == nullptr) {
 		return false;
 	}

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -33,7 +33,7 @@ void LuaAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("configure_gc", "What", "Data"), &LuaAPI::configureGC);
 	ClassDB::bind_method(D_METHOD("get_memory_usage"), &LuaAPI::getMemoryUsage);
 	ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
-	ClassDB::bind_method(D_METHOD("push_module", "Name", "Module"), &LuaAPI::pushGlobalModule);
+	ClassDB::bind_method(D_METHOD("register_library", "Name", "Module"), &LuaAPI::registerLibrary);
 	ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
 	ClassDB::bind_method(D_METHOD("get_registry_value", "Name"), &LuaAPI::getRegistryValue);
 	ClassDB::bind_method(D_METHOD("set_registry_value", "Name", "var"), &LuaAPI::setRegistryValue);
@@ -140,11 +140,10 @@ Ref<LuaError> LuaAPI::pushGlobalVariant(String name, Variant var) {
 	return state.pushGlobalVariant(name, var);
 }
 
-// Calls LuaState::pushGlobalModule()
-// arr must be an array of ['method name', 'method']
-Ref<LuaError> LuaAPI::pushGlobalModule(String name, Array arr) {
-
-	return state.pushGlobalModule(name, arr);
+// Calls LuaState::registerLibrary()
+// arr must be an array shaped as [['method name', 'method']]
+Ref<LuaError> LuaAPI::registerLibrary(String name, Array arr) {
+	return state.registerLibrary(name, arr);
 }
 
 // addFile() calls luaL_loadfille with the absolute file path

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -29,11 +29,11 @@ void LuaAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("do_string", "Code", "Args"), &LuaAPI::doString, DEFVAL(Array()));
 
 	ClassDB::bind_method(D_METHOD("bind_libraries", "Array"), &LuaAPI::bindLibraries);
+	ClassDB::bind_method(D_METHOD("bind_gd_library", "Name", "Module"), &LuaAPI::bindGDLibrary);
 	ClassDB::bind_method(D_METHOD("set_hook", "Hook", "HookMask", "Count"), &LuaAPI::setHook);
 	ClassDB::bind_method(D_METHOD("configure_gc", "What", "Data"), &LuaAPI::configureGC);
 	ClassDB::bind_method(D_METHOD("get_memory_usage"), &LuaAPI::getMemoryUsage);
 	ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
-	ClassDB::bind_method(D_METHOD("register_library", "Name", "Module"), &LuaAPI::registerLibrary);
 	ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
 	ClassDB::bind_method(D_METHOD("get_registry_value", "Name"), &LuaAPI::getRegistryValue);
 	ClassDB::bind_method(D_METHOD("set_registry_value", "Name", "var"), &LuaAPI::setRegistryValue);
@@ -142,8 +142,8 @@ Ref<LuaError> LuaAPI::pushGlobalVariant(String name, Variant var) {
 
 // Calls LuaState::registerLibrary()
 // arr must be an array shaped as [['method name', 'method']]
-Ref<LuaError> LuaAPI::registerLibrary(String name, Array arr) {
-	return state.registerLibrary(name, arr);
+Ref<LuaError> LuaAPI::bindGDLibrary(String name, Array arr) {
+	return state.bindGDLibrary(name, arr);
 }
 
 // addFile() calls luaL_loadfille with the absolute file path

--- a/src/classes/luaAPI.cpp
+++ b/src/classes/luaAPI.cpp
@@ -33,6 +33,7 @@ void LuaAPI::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("configure_gc", "What", "Data"), &LuaAPI::configureGC);
 	ClassDB::bind_method(D_METHOD("get_memory_usage"), &LuaAPI::getMemoryUsage);
 	ClassDB::bind_method(D_METHOD("push_variant", "Name", "var"), &LuaAPI::pushGlobalVariant);
+	ClassDB::bind_method(D_METHOD("push_module", "Name", "Module"), &LuaAPI::pushGlobalModule);
 	ClassDB::bind_method(D_METHOD("pull_variant", "Name"), &LuaAPI::pullVariant);
 	ClassDB::bind_method(D_METHOD("get_registry_value", "Name"), &LuaAPI::getRegistryValue);
 	ClassDB::bind_method(D_METHOD("set_registry_value", "Name", "var"), &LuaAPI::setRegistryValue);
@@ -137,6 +138,13 @@ Variant LuaAPI::callFunction(String functionName, Array args) {
 // Calls LuaState::pushGlobalVariant()
 Ref<LuaError> LuaAPI::pushGlobalVariant(String name, Variant var) {
 	return state.pushGlobalVariant(name, var);
+}
+
+// Calls LuaState::pushGlobalModule()
+// arr must be an array of ['method name', 'method']
+Ref<LuaError> LuaAPI::pushGlobalModule(String name, Array arr) {
+
+	return state.pushGlobalModule(name, arr);
 }
 
 // addFile() calls luaL_loadfille with the absolute file path

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -55,7 +55,7 @@ public:
 	Ref<LuaError> setRegistryValue(String name, Variant var);
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
-	Ref<LuaError> pushGlobalModule(String name, Array arr);
+	Ref<LuaError> registerLibrary(String name, Array arr);
 
 	Ref<LuaCoroutine> newCoroutine();
 	Ref<LuaCoroutine> getRunningCoroutine();

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -55,6 +55,7 @@ public:
 	Ref<LuaError> setRegistryValue(String name, Variant var);
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
+	Ref<LuaError> pushGlobalModule(String name, Array arr);
 
 	Ref<LuaCoroutine> newCoroutine();
 	Ref<LuaCoroutine> getRunningCoroutine();

--- a/src/classes/luaAPI.h
+++ b/src/classes/luaAPI.h
@@ -55,7 +55,7 @@ public:
 	Ref<LuaError> setRegistryValue(String name, Variant var);
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
-	Ref<LuaError> registerLibrary(String name, Array arr);
+	Ref<LuaError> bindGDLibrary(String name, Array arr);
 
 	Ref<LuaCoroutine> newCoroutine();
 	Ref<LuaCoroutine> getRunningCoroutine();

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -499,7 +499,7 @@ Ref<LuaError> LuaState::pushModule(lua_State *state, Array arr) {
 	return nullptr;
 }
 
-// Function opening all godot made lua librearies.
+// Function opening all godot made lua libraries.
 int open_gd_library(lua_State *L) {
 	const char *libname = luaL_checkstring(L, 1);
 	for (int i = 0; i < gdLibraries.size(); i++) {
@@ -520,7 +520,7 @@ int open_gd_library(lua_State *L) {
 }
 
 // Register library into gdLibraries for the current instance of luaState.
-Ref<LuaError> LuaState::registerLibrary(String name, Array arr) {
+Ref<LuaError> LuaState::bindGDLibrary(String name, Array arr) {
 	int idx = -1;
 	for (int i = 0; i < gdLibraries.size(); i++) {
 		if (std::get<1>(gdLibraries[i]) == L) {
@@ -545,13 +545,8 @@ Ref<LuaError> LuaState::registerLibrary(String name, Array arr) {
 		std::get<2>(gdLibraries[idx]).push_back(std::make_pair(name, arr));
 	}
 
-	// I did not understand yet why but default require is disabled.
-	// So push my own which is sandboxed.
-	// Overwrite the previous one if existing with the same require()
-
-	//luaL_requiref(L, name.utf8().get_data(), open_gd_library, true);
-	lua_pushcfunction(L, open_gd_library);
-	lua_setglobal(L, "require");
+	// Reference our lib to be required.
+	luaL_requiref(L, name.utf8().get_data(), open_gd_library, true);
 	return nullptr;
 }
 

--- a/src/luaState.cpp
+++ b/src/luaState.cpp
@@ -531,7 +531,17 @@ Ref<LuaError> LuaState::registerLibrary(String name, Array arr) {
 	// If no library have been registered for the current luaState.
 	if (idx == -1) {
 		gdLibraries.push_back(std::make_tuple(this, L, std::vector<std::pair<String, Array>>{ std::make_pair(name, arr) }));
-	} else {
+	}
+	// If there is already one or more library registered for the current state.
+	else {
+		for(int i = 0; i < std::get<2>(gdLibraries[idx]).size(); i++){
+			// If a library is existing with the same name.
+			if(std::get<2>(gdLibraries[idx])[i].first == name){
+				// Let's erase it.
+				std::get<2>(gdLibraries[idx]).erase(std::get<2>(gdLibraries[idx]).begin() + i);
+				break;
+			}
+		}
 		std::get<2>(gdLibraries[idx]).push_back(std::make_pair(name, arr));
 	}
 

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -19,6 +19,8 @@ class LuaAPI;
 
 class LuaState {
 public:
+
+	~LuaState();
 	void setState(lua_State *state, LuaAPI *lua, bool bindAPI);
 	void setHook(Callable hook, int mask, int count);
 
@@ -36,7 +38,7 @@ public:
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
 	Ref<LuaError> pushVariant(Variant var) const;
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
-	Ref<LuaError> pushGlobalModule(String name, Array var);
+	Ref<LuaError> registerLibrary(String name, Array var);
 	Ref<LuaError> handleError(int lua_error) const;
 
 	static LuaAPI *getAPI(lua_State *state);

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -45,6 +45,7 @@ public:
 
 	static Ref<LuaError> pushVariant(lua_State *state, Variant var);
 	static Ref<LuaError> pushModule(lua_State *state, Array arr);
+	static Ref<LuaError> pushMember(lua_State *state,String name, Variant var);
 	static Ref<LuaError> handleError(lua_State *state, int lua_error);
 #ifndef LAPI_GDEXTENSION
 	static Ref<LuaError> handleError(const StringName &func, Callable::CallError error, const Variant **p_arguments, int argc);

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -36,11 +36,13 @@ public:
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
 	Ref<LuaError> pushVariant(Variant var) const;
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
+	Ref<LuaError> pushGlobalModule(String name, Array var);
 	Ref<LuaError> handleError(int lua_error) const;
 
 	static LuaAPI *getAPI(lua_State *state);
 
 	static Ref<LuaError> pushVariant(lua_State *state, Variant var);
+	static Ref<LuaError> pushModule(lua_State *state, Array arr);
 	static Ref<LuaError> handleError(lua_State *state, int lua_error);
 #ifndef LAPI_GDEXTENSION
 	static Ref<LuaError> handleError(const StringName &func, Callable::CallError error, const Variant **p_arguments, int argc);

--- a/src/luaState.h
+++ b/src/luaState.h
@@ -38,7 +38,7 @@ public:
 	Ref<LuaError> bindLibraries(TypedArray<String> libs);
 	Ref<LuaError> pushVariant(Variant var) const;
 	Ref<LuaError> pushGlobalVariant(String name, Variant var);
-	Ref<LuaError> registerLibrary(String name, Array var);
+	Ref<LuaError> bindGDLibrary(String name, Array var);
 	Ref<LuaError> handleError(int lua_error) const;
 
 	static LuaAPI *getAPI(lua_State *state);


### PR DESCRIPTION
Pull request of a possible implementation to fix #197.

It allows to push a global as follow:
`push_module('my_module_name', [[function_name_1, function_1], [function_name_2, function_2]])`
then we can use it in lua as follow:
`my_module_name. function_name_1()`
`my_module_name. function_name_2()`

It is not registered as a library as since the latest lua release it is a bit tricky.
This PR is WIP and intended for discussion. Yet no unit test and my understanding of Godot_luaAPI is still limited so things might be not ready to merge!

Commits will  be squashed of course before any merge.

Thank you for Godot_luaAPI which is an awesome tool!